### PR TITLE
ci: GitHub Actions for v3 scaffold quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,17 +185,21 @@ jobs:
             up -d dapr-placement daprd-smoketest
 
       - name: Wait for daprd-smoketest healthy
+        # daprd is a distroless image with no /bin/sh, so container-level
+        # healthchecks can't execute. Verify readiness from the host by
+        # curling the exposed HTTP port (same probe smoke tests use).
         run: |
           for i in $(seq 1 60); do
-            state=$(docker inspect --format '{{.State.Health.Status}}' bloodbank-v3-daprd-smoketest 2>/dev/null || echo "missing")
-            if [ "$state" = "healthy" ]; then
-              echo "daprd-smoketest healthy"
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 \
+              http://127.0.0.1:3500/v1.0/healthz 2>/dev/null || echo "000")
+            if [ "$code" = "204" ]; then
+              echo "daprd-smoketest ready (HTTP 204 from /v1.0/healthz)"
               exit 0
             fi
             sleep 2
           done
-          echo "daprd-smoketest never became healthy"
-          docker logs bloodbank-v3-daprd-smoketest
+          echo "daprd-smoketest never responded 204 on /v1.0/healthz"
+          docker logs bloodbank-v3-daprd-smoketest | tail -80
           exit 1
 
       - name: Run smoketest-dapr.sh (Dapr publish)
@@ -212,17 +216,19 @@ jobs:
             up -d echo-sub daprd-subscribe
 
       - name: Wait for daprd-subscribe healthy
+        # Same distroless constraint — probe from host via HTTP.
         run: |
           for i in $(seq 1 60); do
-            state=$(docker inspect --format '{{.State.Health.Status}}' bloodbank-v3-daprd-subscribe 2>/dev/null || echo "missing")
-            if [ "$state" = "healthy" ]; then
-              echo "daprd-subscribe healthy"
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 \
+              http://127.0.0.1:3501/v1.0/healthz 2>/dev/null || echo "000")
+            if [ "$code" = "204" ]; then
+              echo "daprd-subscribe ready (HTTP 204 from /v1.0/healthz)"
               exit 0
             fi
             sleep 2
           done
-          echo "daprd-subscribe never became healthy"
-          docker logs bloodbank-v3-daprd-subscribe
+          echo "daprd-subscribe never responded 204 on /v1.0/healthz"
+          docker logs bloodbank-v3-daprd-subscribe | tail -80
           exit 1
 
       - name: Run smoketest-dapr-subscribe.sh (Dapr publish → subscribe)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,259 @@
+# Bloodbank CI — v3 scaffold quality gate
+#
+# Implements the CI gate contract defined in the metarepo test plan:
+#   docs/testing/test-plan.md (33GOD metarepo)
+#
+# Every PR to v3-refactor or main runs two jobs:
+#   1. static-checks — no Docker; runs in ~1 minute
+#   2. smoke-tests   — spins up the compose sandbox; runs the four smoke
+#                      tests end-to-end
+#
+# The smoke-tests job is the load-bearing signal: if a PR breaks any of
+# the four round-trips, we want to know before merge, not after.
+
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - v3-refactor
+  push:
+    branches:
+      - main
+      - v3-refactor
+
+concurrency:
+  # Cancel in-progress runs on the same branch when a new commit lands.
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Static checks — no Docker, fast feedback
+  # ---------------------------------------------------------------------------
+  static-checks:
+    name: Static checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python deps for validators
+        run: |
+          python -m pip install --upgrade pip
+          # Minimal deps for the static checks; avoids pulling the full
+          # project requirements until we actually need them.
+          pip install pyyaml
+
+      - name: Compile cli/v3
+        # Fails if the operator CLI has a syntax error.
+        run: python -m compileall cli/v3
+
+      - name: Platform bootstrap check
+        # Pure file-presence validator; no Docker, no network.
+        run: bash ops/v3/bootstrap/check-platform.sh
+
+      - name: bb_v3 doctor
+        # Manifest-driven scaffold check. Should match bootstrap exactly.
+        run: python3 cli/v3/bb_v3.py doctor
+
+      - name: Validate Dapr component YAML
+        run: |
+          python -c "import yaml, sys
+          for f in [
+            'compose/v3/components/pubsub.yaml',
+            'compose/v3/components/statestore.yaml',
+            'compose/v3/components/secretstore.yaml',
+          ]:
+            yaml.safe_load(open(f))
+            print(f'OK  {f}')"
+
+      - name: Validate NATS streams.json
+        run: |
+          python -c "import json
+          d = json.load(open('compose/v3/nats/streams.json'))
+          assert 'streams' in d
+          names = {s['name'] for s in d['streams']}
+          assert 'BLOODBANK_V3_EVENTS' in names
+          assert 'BLOODBANK_V3_COMMANDS' in names
+          print(f'OK  {sorted(names)}')"
+
+      - name: Validate docker compose config parses
+        # Uses the builtin docker compose; no services started.
+        run: docker compose --project-name bloodbank-v3 -f compose/v3/docker-compose.yml config > /dev/null
+
+      - name: Lint shell scripts
+        # shellcheck catches most of the classes of bug we've already hit live
+        # (stdin-pipe+heredoc is the common antipattern).
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq shellcheck
+          shellcheck -S warning \
+            ops/v3/bootstrap/check-platform.sh \
+            compose/v3/nats/init.sh \
+            ops/v3/smoketest/smoketest.sh \
+            ops/v3/smoketest/smoketest-dapr.sh \
+            ops/v3/smoketest/smoketest-dapr-subscribe.sh \
+            ops/v3/smoketest/smoketest-command.sh || true
+          # `|| true` for now — shellcheck findings surface but don't block
+          # until we decide which warnings to treat as blockers. Revisit
+          # after first real review pass.
+
+  # ---------------------------------------------------------------------------
+  # Smoke tests — boot the compose sandbox, run all four round-trips
+  # ---------------------------------------------------------------------------
+  smoke-tests:
+    name: Smoke tests (Dapr + NATS end-to-end)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: static-checks
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Docker version
+        # Surface the environment in the log for debugging.
+        run: |
+          docker version
+          docker compose version
+
+      - name: Pre-pull sandbox images
+        # Warm the local image cache so healthcheck windows aren't racing
+        # image pulls. Keeps logs readable and timings stable.
+        run: |
+          docker pull nats:2.10-alpine
+          docker pull natsio/nats-box:0.14.5
+          docker pull daprio/dapr:1.13.0
+          docker pull daprio/daprd:1.13.0
+          docker pull python:3.11-alpine
+
+      # -----------------------------------------------------------------------
+      # Layer 1: NATS-direct tests (no Dapr)
+      # -----------------------------------------------------------------------
+      - name: Boot NATS sandbox
+        run: |
+          docker compose --project-name bloodbank-v3 \
+            -f compose/v3/docker-compose.yml \
+            up -d nats nats-init
+
+      - name: Wait for nats-init to finish
+        run: |
+          # nats-init is oneshot; wait up to 60s for it to exit successfully.
+          for i in $(seq 1 30); do
+            state=$(docker inspect --format '{{.State.Status}}' bloodbank-v3-nats-init 2>/dev/null || echo "missing")
+            if [ "$state" = "exited" ]; then
+              code=$(docker inspect --format '{{.State.ExitCode}}' bloodbank-v3-nats-init)
+              if [ "$code" = "0" ]; then
+                echo "nats-init exited 0"
+                exit 0
+              else
+                echo "nats-init exited $code"
+                docker logs bloodbank-v3-nats-init
+                exit 1
+              fi
+            fi
+            sleep 2
+          done
+          echo "nats-init did not finish in time"
+          docker logs bloodbank-v3-nats-init
+          exit 1
+
+      - name: Run smoketest.sh (NATS direct event)
+        run: bash ops/v3/smoketest/smoketest.sh
+
+      - name: Run smoketest-command.sh (NATS direct command + reply)
+        run: bash ops/v3/smoketest/smoketest-command.sh
+
+      # -----------------------------------------------------------------------
+      # Layer 2: Dapr publish test
+      # -----------------------------------------------------------------------
+      - name: Boot daprd-smoketest
+        run: |
+          docker compose --project-name bloodbank-v3 \
+            --profile dapr-smoketest \
+            -f compose/v3/docker-compose.yml \
+            up -d dapr-placement daprd-smoketest
+
+      - name: Wait for daprd-smoketest healthy
+        run: |
+          for i in $(seq 1 60); do
+            state=$(docker inspect --format '{{.State.Health.Status}}' bloodbank-v3-daprd-smoketest 2>/dev/null || echo "missing")
+            if [ "$state" = "healthy" ]; then
+              echo "daprd-smoketest healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "daprd-smoketest never became healthy"
+          docker logs bloodbank-v3-daprd-smoketest
+          exit 1
+
+      - name: Run smoketest-dapr.sh (Dapr publish)
+        run: bash ops/v3/smoketest/smoketest-dapr.sh
+
+      # -----------------------------------------------------------------------
+      # Layer 3: Dapr subscribe test
+      # -----------------------------------------------------------------------
+      - name: Boot echo-sub + daprd-subscribe
+        run: |
+          docker compose --project-name bloodbank-v3 \
+            --profile dapr-subscribe \
+            -f compose/v3/docker-compose.yml \
+            up -d echo-sub daprd-subscribe
+
+      - name: Wait for daprd-subscribe healthy
+        run: |
+          for i in $(seq 1 60); do
+            state=$(docker inspect --format '{{.State.Health.Status}}' bloodbank-v3-daprd-subscribe 2>/dev/null || echo "missing")
+            if [ "$state" = "healthy" ]; then
+              echo "daprd-subscribe healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "daprd-subscribe never became healthy"
+          docker logs bloodbank-v3-daprd-subscribe
+          exit 1
+
+      - name: Run smoketest-dapr-subscribe.sh (Dapr publish → subscribe)
+        run: bash ops/v3/smoketest/smoketest-dapr-subscribe.sh
+
+      # -----------------------------------------------------------------------
+      # Diagnostics on failure; always collect
+      # -----------------------------------------------------------------------
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== docker compose ps ==="
+          docker compose --project-name bloodbank-v3 \
+            --profile dapr-smoketest --profile dapr-subscribe \
+            -f compose/v3/docker-compose.yml \
+            ps || true
+          echo "=== nats logs ==="
+          docker logs bloodbank-v3-nats 2>&1 | tail -80 || true
+          echo "=== nats-init logs ==="
+          docker logs bloodbank-v3-nats-init 2>&1 | tail -80 || true
+          echo "=== daprd-smoketest logs ==="
+          docker logs bloodbank-v3-daprd-smoketest 2>&1 | tail -80 || true
+          echo "=== daprd-subscribe logs ==="
+          docker logs bloodbank-v3-daprd-subscribe 2>&1 | tail -80 || true
+          echo "=== echo-sub logs ==="
+          docker logs bloodbank-v3-echo-sub 2>&1 | tail -80 || true
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker compose --project-name bloodbank-v3 \
+            --profile dapr-smoketest --profile dapr-subscribe \
+            -f compose/v3/docker-compose.yml \
+            down -v || true

--- a/compose/v3/docker-compose.yml
+++ b/compose/v3/docker-compose.yml
@@ -161,12 +161,11 @@ services:
       # compose network (no external caller needs it for the subscribe
       # smoke test).
       - "${BLOODBANK_V3_DAPR_SUBSCRIBE_HTTP_PORT:-3501}:3501"
-    healthcheck:
-      test: ["CMD-SHELL", "wget --spider --quiet --timeout=3 http://127.0.0.1:3501/v1.0/healthz || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
+    # NOTE: no container-level healthcheck. daprio/daprd:1.13.0 is a
+    # distroless image with no /bin/sh, so CMD-SHELL checks never execute;
+    # the container stays "starting" then transitions to "unhealthy" even
+    # when Dapr is fully up. Readiness is verified externally via
+    # curl :3501/v1.0/healthz (both smoke tests and CI do this).
     networks:
       - bloodbank-v3-network
     restart: unless-stopped
@@ -202,13 +201,9 @@ services:
     ports:
       - "${BLOODBANK_V3_DAPR_HTTP_PORT:-3500}:3500"
       - "${BLOODBANK_V3_DAPR_GRPC_PORT:-50001}:50001"
-    healthcheck:
-      # Dapr exposes its own healthz on the HTTP port once components load.
-      test: ["CMD-SHELL", "wget --spider --quiet --timeout=3 http://127.0.0.1:3500/v1.0/healthz || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
+    # NOTE: no container-level healthcheck. Same distroless constraint as
+    # daprd-subscribe above. Readiness is verified externally via
+    # curl :3500/v1.0/healthz.
     networks:
       - bloodbank-v3-network
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Implements the CI gate contract from [metarepo `docs/testing/test-plan.md`](https://github.com/delorenj/33GOD/blob/main/docs/testing/test-plan.md). Two jobs run on every PR and push to `v3-refactor` / `main`.

## Jobs

### 1. `static-checks` (~1 min, fast feedback)

- `python -m compileall cli/v3`
- `bash ops/v3/bootstrap/check-platform.sh`
- `python cli/v3/bb_v3.py doctor`
- Validates all Dapr component YAML
- Validates `nats/streams.json` + both streams present
- `docker compose config`
- `shellcheck` all scripts (findings surface, not blocking yet)

### 2. `smoke-tests` (~5-10 min, depends on static-checks)

- Pre-pull images to stabilize timing
- NATS layer: `smoketest.sh` + `smoketest-command.sh`
- Dapr publish layer: `smoketest-dapr.sh`
- Dapr subscribe layer: `smoketest-dapr-subscribe.sh`
- Diagnostics collection on any failure (all container logs captured)
- `docker compose down -v` always runs

## Design choices

- `needs: static-checks` on smoke-tests — broken compose fails fast without spinning up images
- Each layer boots only its services, with a visible wait loop so startup races surface in CI logs
- `concurrency` group cancels in-progress runs on new commits (no wasted minutes)
- Shellcheck non-blocking pending first triage pass

## First signal

This PR itself should trigger the workflow once opened; we see the first CI run as proof of life.

## Test plan

- [ ] PR opens, `static-checks` + `smoke-tests` jobs appear in the checks tab
- [ ] `static-checks` passes
- [ ] `smoke-tests` completes all four smoketests PASS
- [ ] No dangling containers/networks after job ends