### PR TITLE
chore(ci): drop v3-refactor from CI triggers (branch retired)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 # Implements the CI gate contract defined in the metarepo test plan:
 #   docs/testing/test-plan.md (33GOD metarepo)
 #
-# Every PR to v3-refactor or main runs two jobs:
+# Every PR to main runs two jobs:
 #   1. static-checks — no Docker; runs in ~1 minute
 #   2. smoke-tests   — spins up the compose sandbox; runs the four smoke
 #                      tests end-to-end
@@ -17,11 +17,9 @@ on:
   pull_request:
     branches:
       - main
-      - v3-refactor
   push:
     branches:
       - main
-      - v3-refactor
 
 concurrency:
   # Cancel in-progress runs on the same branch when a new commit lands.


### PR DESCRIPTION
## Summary

Bloodbank main was fast-forwarded to the `v3-refactor` tip and the long-lived branch retired (tag `v3-mainline-cutover-2026-04-26` marks the moment). CI triggers now only watch `main`.

Per the metarepo `git-workflow-and-versioning` skill: "Long-lived branches are hidden costs. Dev branches are costs. Keep main always deployable."

## Changes

- Drop `v3-refactor` from `pull_request.branches` and `push.branches`
- Update header comment

## Test plan

- [ ] PR opens; workflow runs and passes (it must, since CI itself isn't changed beyond triggers)
- [ ] After merge, future PRs to `main` trigger correctly