### PR TITLE
feat(services): heartbeat — first real-world v3 event end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,15 @@ jobs:
           docker pull daprio/daprd:1.13.0
           docker pull python:3.11-alpine
 
+      - name: Pre-build heartbeat service images
+        # heartbeat-tick + heartbeat-recorder build from local Dockerfiles;
+        # build them eagerly so the smoke test isn't waiting on the build.
+        run: |
+          docker compose --project-name bloodbank-v3 \
+            --profile heartbeat \
+            -f compose/v3/docker-compose.yml \
+            build heartbeat-recorder heartbeat-tick
+
       # -----------------------------------------------------------------------
       # Layer 1: NATS-direct tests (no Dapr)
       # -----------------------------------------------------------------------
@@ -233,6 +242,35 @@ jobs:
         run: bash ops/v3/smoketest/smoketest-dapr-subscribe.sh
 
       # -----------------------------------------------------------------------
+      # Layer 4: heartbeat — first real-world v3 event end-to-end
+      # -----------------------------------------------------------------------
+      - name: Boot heartbeat profile (recorder + daprd-heartbeat + tick)
+        run: |
+          docker compose --project-name bloodbank-v3 \
+            --profile heartbeat \
+            -f compose/v3/docker-compose.yml \
+            up -d --build heartbeat-recorder daprd-heartbeat heartbeat-tick
+
+      - name: Wait for daprd-heartbeat ready
+        run: |
+          for i in $(seq 1 60); do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 \
+              http://127.0.0.1:3502/v1.0/healthz 2>/dev/null || echo "000")
+            if [ "$code" = "204" ]; then
+              echo "daprd-heartbeat ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "daprd-heartbeat never responded 204"
+          docker logs bloodbank-v3-daprd-heartbeat | tail -50
+          exit 1
+
+      - name: Run smoketest-heartbeat.sh (real producer/consumer round-trip)
+        # Default 5s tick interval; smoketest waits 15s for >= 2 ticks.
+        run: bash ops/v3/smoketest/smoketest-heartbeat.sh
+
+      # -----------------------------------------------------------------------
       # Diagnostics on failure; always collect
       # -----------------------------------------------------------------------
       - name: Collect diagnostics on failure
@@ -240,24 +278,19 @@ jobs:
         run: |
           echo "=== docker compose ps ==="
           docker compose --project-name bloodbank-v3 \
-            --profile dapr-smoketest --profile dapr-subscribe \
+            --profile dapr-smoketest --profile dapr-subscribe --profile heartbeat \
             -f compose/v3/docker-compose.yml \
             ps || true
-          echo "=== nats logs ==="
-          docker logs bloodbank-v3-nats 2>&1 | tail -80 || true
-          echo "=== nats-init logs ==="
-          docker logs bloodbank-v3-nats-init 2>&1 | tail -80 || true
-          echo "=== daprd-smoketest logs ==="
-          docker logs bloodbank-v3-daprd-smoketest 2>&1 | tail -80 || true
-          echo "=== daprd-subscribe logs ==="
-          docker logs bloodbank-v3-daprd-subscribe 2>&1 | tail -80 || true
-          echo "=== echo-sub logs ==="
-          docker logs bloodbank-v3-echo-sub 2>&1 | tail -80 || true
+          for c in nats nats-init daprd-smoketest daprd-subscribe echo-sub \
+                   daprd-heartbeat heartbeat-recorder heartbeat-tick; do
+            echo "=== ${c} logs ==="
+            docker logs "bloodbank-v3-${c}" 2>&1 | tail -80 || true
+          done
 
       - name: Tear down
         if: always()
         run: |
           docker compose --project-name bloodbank-v3 \
-            --profile dapr-smoketest --profile dapr-subscribe \
+            --profile dapr-smoketest --profile dapr-subscribe --profile heartbeat \
             -f compose/v3/docker-compose.yml \
             down -v || true

--- a/compose/v3/components/pubsub.yaml
+++ b/compose/v3/components/pubsub.yaml
@@ -33,10 +33,17 @@ spec:
       value: "nats://nats:4222"
     - name: name
       value: "bloodbank-v3-pubsub"
-    # Durable consumer identifier. Keeps offsets per-component across
-    # sidecar restarts so replay-on-restart is explicit rather than silent.
-    - name: durableName
-      value: "bloodbank-v3-pubsub"
+    # NOTE: durableName is intentionally UNSET. With multiple Dapr
+    # sidecars (daprd-subscribe, daprd-heartbeat, future services) all
+    # loading this same component manifest, a fixed durableName causes
+    # the second sidecar's subscribe binding to fail with
+    #   "nats: subject does not match consumer"
+    # because JetStream's durable consumer is tied to a single filter
+    # subject, and different sidecars subscribe to different topics.
+    # Leaving durableName empty makes each sidecar create its own
+    # ephemeral consumer. Production services that need durable
+    # cross-restart offsets should supply their own per-service
+    # component manifest with an app-id-suffixed durableName.
     # Queue group scopes competing consumers; replicas of the same service
     # share this group and each message goes to exactly one replica.
     - name: queueGroupName

--- a/compose/v3/docker-compose.yml
+++ b/compose/v3/docker-compose.yml
@@ -170,6 +170,98 @@ services:
       - bloodbank-v3-network
     restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # Heartbeat — first real-world v3 event (system.heartbeat.tick)
+  # ---------------------------------------------------------------------------
+  # Three services behind the `heartbeat` compose profile:
+  #   - heartbeat-recorder: subscriber app on port 3001 (mirrors echo-sub
+  #     pattern; records ticks + exposes /inspect/recorded for tests)
+  #   - daprd-heartbeat: sidecar attached to recorder via --app-port; ALSO
+  #     services heartbeat-tick's publish requests via its HTTP API
+  #   - heartbeat-tick: long-running publisher emitting on a 5s interval
+  #     by default; configurable via HEARTBEAT_INTERVAL env var
+
+  heartbeat-recorder:
+    build:
+      context: ../../services/heartbeat-recorder
+    container_name: bloodbank-v3-heartbeat-recorder
+    profiles:
+      - heartbeat
+    environment:
+      APP_PORT: "3001"
+      SUBSCRIBE_PUBSUB: "bloodbank-v3-pubsub"
+      SUBSCRIBE_TOPIC: "event.system.heartbeat.tick"
+      SUBSCRIBE_ROUTE: "/events/heartbeat"
+    ports:
+      # Test-hook port for /inspect/recorded queries from the host.
+      - "${BLOODBANK_V3_HEARTBEAT_RECORDER_PORT:-3601}:3001"
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider --quiet --timeout=3 http://127.0.0.1:3001/healthz || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 3s
+    networks:
+      - bloodbank-v3-network
+    restart: unless-stopped
+
+  daprd-heartbeat:
+    image: daprio/daprd:1.13.0
+    container_name: bloodbank-v3-daprd-heartbeat
+    profiles:
+      - heartbeat
+    command:
+      - "./daprd"
+      - "--app-id=bloodbank-v3-heartbeat"
+      - "--dapr-http-port=3500"
+      - "--dapr-grpc-port=50001"
+      - "--app-port=3001"
+      - "--app-channel-address=heartbeat-recorder"
+      - "--app-protocol=http"
+      - "--resources-path=/components"
+      - "--placement-host-address=dapr-placement:50005"
+      - "--log-level=info"
+    depends_on:
+      nats-init:
+        condition: service_completed_successfully
+      dapr-placement:
+        condition: service_started
+      heartbeat-recorder:
+        condition: service_healthy
+    volumes:
+      - ./components:/components:ro
+    ports:
+      # Optional: expose Dapr HTTP for ad-hoc curls from the host.
+      - "${BLOODBANK_V3_DAPR_HEARTBEAT_HTTP_PORT:-3502}:3500"
+    # No container-level healthcheck (distroless image). Liveness is
+    # verified externally via curl :3502/v1.0/healthz.
+    networks:
+      - bloodbank-v3-network
+    restart: unless-stopped
+
+  heartbeat-tick:
+    build:
+      context: ../../services/heartbeat-tick
+    container_name: bloodbank-v3-heartbeat-tick
+    profiles:
+      - heartbeat
+    environment:
+      DAPR_HTTP_HOST: "daprd-heartbeat"
+      DAPR_HTTP_PORT: "3500"
+      DAPR_PUBSUB: "bloodbank-v3-pubsub"
+      HEARTBEAT_TOPIC: "event.system.heartbeat.tick"
+      HEARTBEAT_INTERVAL: "${BLOODBANK_V3_HEARTBEAT_INTERVAL:-5}"
+      LOG_LEVEL: "INFO"
+    depends_on:
+      # daprd-heartbeat needs to be up before tick can publish.
+      # Container "started" is enough — heartbeat-tick has its own
+      # 60s health-wait loop on the daprd HTTP API before first publish.
+      daprd-heartbeat:
+        condition: service_started
+    networks:
+      - bloodbank-v3-network
+    restart: unless-stopped
+
   daprd-smoketest:
     # Dapr sidecar in "no-app" mode for smoke-testing the publish path.
     # Runs without an attached app (subscribers would need an app callback

--- a/compose/v3/nats/init.sh
+++ b/compose/v3/nats/init.sh
@@ -106,5 +106,34 @@ while [ "${i}" -lt "${streams_count}" ]; do
   i=$((i + 1))
 done
 
+# Verification gate: confirm every stream is reachable from a FRESH
+# connection before exiting. JetStream metadata can lag a few hundred ms
+# behind a successful `stream add`; if nats-init exits while the
+# metadata is still propagating, a downstream consumer (e.g. Dapr's
+# pubsub.jetstream) that connects in that window can hit
+# "nats: stream not found" on its initial subscribe binding. Verifying
+# from a separate `nats stream info` call (different connection) forces
+# the propagation to land.
+echo "nats-init: verifying streams are queryable from a fresh connection"
+verify_attempts=10
+i=0
+while [ "${i}" -lt "${streams_count}" ]; do
+  name=$(jq -r ".streams[${i}].name" "${STREAMS_JSON}")
+  attempt=0
+  while [ "${attempt}" -lt "${verify_attempts}" ]; do
+    if nats --server="${NATS_URL}" stream info "${name}" >/dev/null 2>&1; then
+      echo "nats-init: ${name} OK (attempt $((attempt + 1)))"
+      break
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.5
+  done
+  if [ "${attempt}" -ge "${verify_attempts}" ]; then
+    echo "nats-init: ${name} FAILED to verify after ${verify_attempts} attempts" >&2
+    exit 1
+  fi
+  i=$((i + 1))
+done
+
 echo "nats-init: done"
 exit 0

--- a/ops/v3/smoketest/smoketest-heartbeat.sh
+++ b/ops/v3/smoketest/smoketest-heartbeat.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Bloodbank v3 heartbeat integration smoke test — first real-world event.
+#
+# Unlike the other smoketests under this directory (which probe transport
+# with ephemeral publishes), this one verifies the full first-real-event
+# pipeline:
+#
+#   heartbeat-tick (long-running publisher)
+#     → daprd-heartbeat (Dapr pub/sub through pubsub.jetstream)
+#       → BLOODBANK_V3_EVENTS stream on NATS JetStream
+#         → daprd-heartbeat consumer (with --app-port to recorder)
+#           → heartbeat-recorder (HTTP callback / records to memory)
+#
+# The test then queries heartbeat-recorder's /inspect/recorded endpoint
+# and asserts:
+#   - At least N ticks have arrived (default N=2)
+#   - tick_seq is monotonic (no skips, no duplicates within one producer)
+#   - All ticks share the same producer_id and started_at
+#   - Each envelope is shape-valid CloudEvents 1.0 with the heartbeat data
+#
+# Preconditions (caller responsibility):
+#   docker compose --project-name bloodbank-v3 --profile heartbeat \
+#     -f compose/v3/docker-compose.yml \
+#     up -d nats nats-init dapr-placement heartbeat-recorder \
+#           daprd-heartbeat heartbeat-tick
+#
+# Usage:
+#   bash ops/v3/smoketest/smoketest-heartbeat.sh
+#   bash ops/v3/smoketest/smoketest-heartbeat.sh --min-ticks 4 --wait 25
+#
+# Exit codes:
+#   0 — PASS
+#   1 — sandbox not reachable, recorder unhealthy, or tick count below min
+#   2 — envelope validation failed
+
+set -euo pipefail
+
+RECORDER_HTTP="${RECORDER_HTTP:-http://127.0.0.1:3601}"
+MIN_TICKS=2
+WAIT_SECONDS=15
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --min-ticks)     MIN_TICKS="${2:-}"; shift 2;;
+    --min-ticks=*)   MIN_TICKS="${1#*=}"; shift;;
+    --wait)          WAIT_SECONDS="${2:-}"; shift 2;;
+    --wait=*)        WAIT_SECONDS="${1#*=}"; shift;;
+    -h|--help)       sed -n '3,28p' "${BASH_SOURCE[0]}"; exit 0;;
+    *)               echo "smoketest-heartbeat: unknown arg: $1" >&2; exit 1;;
+  esac
+done
+
+echo "smoketest-heartbeat: min_ticks=${MIN_TICKS} wait=${WAIT_SECONDS}s recorder=${RECORDER_HTTP}"
+
+fail() { local rc="$1"; shift; echo "smoketest-heartbeat: FAIL -- $*" >&2; exit "${rc}"; }
+
+# -----------------------------------------------------------------------------
+# 1. Recorder must be reachable + healthy
+# -----------------------------------------------------------------------------
+code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${RECORDER_HTTP}/healthz" 2>/dev/null || echo "000")
+if [[ "${code}" != "204" ]]; then
+  fail 1 "heartbeat-recorder healthz did not return 204 at ${RECORDER_HTTP}/healthz (got ${code})"
+fi
+
+# -----------------------------------------------------------------------------
+# 2. Reset the buffer so this run isn't polluted by prior ticks
+# -----------------------------------------------------------------------------
+curl -sS -X POST "${RECORDER_HTTP}/inspect/reset" >/dev/null \
+  || fail 1 "could not reset recorder buffer"
+
+echo "smoketest-heartbeat: recorder buffer reset; waiting ${WAIT_SECONDS}s for ticks"
+
+# -----------------------------------------------------------------------------
+# 3. Wait for ticks to land. Poll every 2s, exit early if we hit min.
+# -----------------------------------------------------------------------------
+deadline=$(( $(date +%s) + WAIT_SECONDS ))
+final_count=0
+while [[ $(date +%s) -lt ${deadline} ]]; do
+  count=$(curl -sS --max-time 3 "${RECORDER_HTTP}/inspect/recorded" 2>/dev/null \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['count'])" 2>/dev/null \
+    || echo 0)
+  if [[ "${count}" -ge "${MIN_TICKS}" ]]; then
+    final_count="${count}"
+    break
+  fi
+  sleep 2
+done
+
+if [[ "${final_count}" -lt "${MIN_TICKS}" ]]; then
+  echo "smoketest-heartbeat: only ${final_count} ticks after ${WAIT_SECONDS}s (need ${MIN_TICKS})"
+  echo "Recorder dump:"
+  curl -sS "${RECORDER_HTTP}/inspect/recorded" | python3 -m json.tool >&2 || true
+  fail 1 "tick count below threshold (${final_count} < ${MIN_TICKS})"
+fi
+
+echo "smoketest-heartbeat: ${final_count} ticks observed"
+
+# -----------------------------------------------------------------------------
+# 4. Validate shape + monotonic invariants
+# -----------------------------------------------------------------------------
+RECEIVED_JSON="$(curl -sS --max-time 3 "${RECORDER_HTTP}/inspect/recorded" 2>/dev/null)"
+
+python3 -c "
+import json, sys
+data = json.loads(sys.argv[1])
+min_ticks = int(sys.argv[2])
+
+envelopes = data.get('envelopes', [])
+producers = data.get('producers', [])
+
+problems = []
+
+# 1. Envelope-level shape
+for i, env in enumerate(envelopes):
+    if not isinstance(env, dict):
+        problems.append(f'envelope[{i}] is not an object')
+        continue
+    for required in ('specversion', 'id', 'source', 'type', 'time', 'correlationid', 'producer', 'service', 'domain', 'data'):
+        if required not in env:
+            problems.append(f'envelope[{i}] missing {required!r}')
+    if env.get('specversion') != '1.0':
+        problems.append(f\"envelope[{i}] specversion = {env.get('specversion')!r}, want '1.0'\")
+    if env.get('type') != 'system.heartbeat.tick':
+        problems.append(f\"envelope[{i}] type = {env.get('type')!r}, want 'system.heartbeat.tick'\")
+    if env.get('domain') != 'system':
+        problems.append(f\"envelope[{i}] domain = {env.get('domain')!r}, want 'system'\")
+    d = env.get('data', {})
+    for required in ('tick_seq', 'producer_id', 'started_at'):
+        if required not in d:
+            problems.append(f'envelope[{i}].data missing {required!r}')
+
+# 2. Producer summary: exactly one producer (the heartbeat-tick instance)
+if len(producers) != 1:
+    problems.append(f'expected exactly 1 producer summary, got {len(producers)}')
+
+# 3. Monotonic sequence per producer
+for prod in producers:
+    pid = prod.get('producer_id')
+    expected_count = prod.get('last_tick_seq', -1) - prod.get('first_tick_seq', 0) + 1
+    if prod.get('count') != expected_count:
+        problems.append(
+            f\"producer {pid} count={prod.get('count')} but range \"
+            f\"[{prod.get('first_tick_seq')}, {prod.get('last_tick_seq')}] \"
+            f\"implies {expected_count} (gap or duplicate)\"
+        )
+
+# 4. All envelopes share producer_id and started_at
+producer_ids = {env.get('data', {}).get('producer_id') for env in envelopes}
+started_ats = {env.get('data', {}).get('started_at') for env in envelopes}
+if len(producer_ids) > 1:
+    problems.append(f'multiple producer_ids in single run: {producer_ids}')
+if len(started_ats) > 1:
+    problems.append(f'multiple started_at values in single run: {started_ats}')
+
+if problems:
+    print('heartbeat smoke validation failed:', file=sys.stderr)
+    for p in problems:
+        print(f'  - {p}', file=sys.stderr)
+    sys.exit(2)
+print(f'OK: {len(envelopes)} envelopes, {len(producers)} producer(s), all monotonic')
+sys.exit(0)
+" "${RECEIVED_JSON}" "${MIN_TICKS}" \
+  || fail 2 "envelope validation failed"
+
+echo "smoketest-heartbeat: PASS"
+exit 0

--- a/services/heartbeat-recorder/Dockerfile
+++ b/services/heartbeat-recorder/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-alpine
+
+WORKDIR /app
+COPY main.py /app/main.py
+
+RUN adduser -D -u 10002 -h /app appuser \
+ && chown -R appuser /app
+USER appuser
+
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 3001
+
+ENTRYPOINT ["python", "-u", "/app/main.py"]

--- a/services/heartbeat-recorder/main.py
+++ b/services/heartbeat-recorder/main.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Heartbeat tick recorder — subscribes via Dapr and records each tick.
+
+Bookend to heartbeat-tick. Implements the Dapr programmatic subscription
+contract (mirrors ops/v3/smoketest/echo-sub/app.py) but with stronger
+typing intent: it counts ticks, captures the latest envelope per
+producer_id, and exposes test hooks.
+
+Endpoints:
+  GET  /dapr/subscribe       Dapr subscription list
+  POST /events/heartbeat     Dapr delivers heartbeat ticks here
+  GET  /inspect/recorded     test hook: count, latest, producer_summary
+  POST /inspect/reset        test hook: clear recorded buffer
+  GET  /healthz              liveness probe
+
+Schema source of truth: holyfields/schemas/system/heartbeat.tick.v1.json
+
+Configuration:
+  APP_PORT             HTTP port (default: 3001)
+  SUBSCRIBE_PUBSUB     Dapr pubsub component (default: bloodbank-v3-pubsub)
+  SUBSCRIBE_TOPIC      Subscription topic (default: event.system.heartbeat.tick)
+  SUBSCRIBE_ROUTE      Delivery route (default: /events/heartbeat)
+  MAX_BUFFER           Max recorded envelopes (default: 1024; FIFO eviction)
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from collections import deque
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Deque
+
+APP_PORT = int(os.environ.get("APP_PORT", "3001"))
+SUBSCRIBE_PUBSUB = os.environ.get("SUBSCRIBE_PUBSUB", "bloodbank-v3-pubsub")
+SUBSCRIBE_TOPIC = os.environ.get("SUBSCRIBE_TOPIC", "event.system.heartbeat.tick")
+SUBSCRIBE_ROUTE = os.environ.get("SUBSCRIBE_ROUTE", "/events/heartbeat")
+MAX_BUFFER = int(os.environ.get("MAX_BUFFER", "1024"))
+
+_lock = threading.Lock()
+_received: Deque[dict] = deque(maxlen=MAX_BUFFER)
+# Per-producer summary so tests can verify monotonic tick_seq without
+# walking the entire buffer.
+_producer_summary: dict[str, dict] = {}
+
+
+def _subscribe_response() -> list[dict]:
+    return [
+        {
+            "pubsubname": SUBSCRIBE_PUBSUB,
+            "topic": SUBSCRIBE_TOPIC,
+            "route": SUBSCRIBE_ROUTE,
+        }
+    ]
+
+
+def _record(envelope: dict) -> None:
+    """Append an envelope to the buffer and update per-producer summary."""
+    with _lock:
+        _received.append(envelope)
+        data = envelope.get("data", {}) if isinstance(envelope, dict) else {}
+        producer_id = data.get("producer_id")
+        tick_seq = data.get("tick_seq")
+        if isinstance(producer_id, str) and isinstance(tick_seq, int):
+            entry = _producer_summary.get(producer_id) or {
+                "producer_id": producer_id,
+                "first_tick_seq": tick_seq,
+                "last_tick_seq": tick_seq,
+                "count": 0,
+                "started_at": data.get("started_at"),
+            }
+            entry["last_tick_seq"] = max(entry["last_tick_seq"], tick_seq)
+            entry["first_tick_seq"] = min(entry["first_tick_seq"], tick_seq)
+            entry["count"] += 1
+            _producer_summary[producer_id] = entry
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        return  # silence default per-request log
+
+    def _send_json(self, status: int, body: object) -> None:
+        payload = json.dumps(body).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _send_empty(self, status: int) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/dapr/subscribe":
+            self._send_json(200, _subscribe_response())
+            return
+
+        if self.path == "/inspect/recorded":
+            with _lock:
+                envelopes = list(_received)
+                summary = list(_producer_summary.values())
+            latest = envelopes[-1] if envelopes else None
+            self._send_json(
+                200,
+                {
+                    "count": len(envelopes),
+                    "latest": latest,
+                    "producers": summary,
+                    "envelopes": envelopes,
+                },
+            )
+            return
+
+        if self.path == "/healthz":
+            self._send_empty(204)
+            return
+
+        self._send_empty(404)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path == SUBSCRIBE_ROUTE:
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            raw = self.rfile.read(length) if length > 0 else b""
+            try:
+                envelope = json.loads(raw.decode("utf-8")) if raw else None
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                self._send_empty(400)
+                return
+
+            if not isinstance(envelope, dict):
+                self._send_empty(400)
+                return
+
+            _record(envelope)
+
+            with _lock:
+                buffer_size = len(_received)
+            print(
+                f"heartbeat-recorder: recorded "
+                f"tick_seq={envelope.get('data', {}).get('tick_seq')} "
+                f"producer_id={envelope.get('data', {}).get('producer_id')} "
+                f"buffer={buffer_size}/{MAX_BUFFER}",
+                file=sys.stdout,
+                flush=True,
+            )
+            # Dapr expects a status acknowledgement.
+            self._send_json(200, {"status": "SUCCESS"})
+            return
+
+        if self.path == "/inspect/reset":
+            with _lock:
+                cleared = len(_received)
+                _received.clear()
+                _producer_summary.clear()
+            self._send_json(200, {"cleared": cleared})
+            return
+
+        self._send_empty(404)
+
+
+def main() -> int:
+    server = ThreadingHTTPServer(("0.0.0.0", APP_PORT), Handler)
+    print(
+        f"heartbeat-recorder: listening on 0.0.0.0:{APP_PORT} | "
+        f"subscribe {SUBSCRIBE_PUBSUB}/{SUBSCRIBE_TOPIC} -> {SUBSCRIBE_ROUTE}",
+        flush=True,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/heartbeat-tick/Dockerfile
+++ b/services/heartbeat-tick/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-alpine
+
+# heartbeat-tick is stdlib-only (urllib + json); no extra deps needed.
+# Keeps the image tiny (~50MB total).
+
+WORKDIR /app
+COPY main.py /app/main.py
+
+# Run as a non-root user. python:alpine ships with no useradd, so use
+# adduser in BusyBox style.
+RUN adduser -D -u 10001 -h /app appuser \
+ && chown -R appuser /app
+USER appuser
+
+# Unbuffered stdout for real-time CI logs.
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["python", "-u", "/app/main.py"]

--- a/services/heartbeat-tick/README.md
+++ b/services/heartbeat-tick/README.md
@@ -1,0 +1,108 @@
+# heartbeat-tick
+
+Long-running service that emits `system.heartbeat.tick` events through
+Dapr pub/sub on a configurable interval. Bookended by
+[`../heartbeat-recorder/`](../heartbeat-recorder/) which subscribes,
+records, and exposes inspection hooks for tests.
+
+Together these two services are the **first real-world domain event**
+in the v3 platform.
+
+## Architecture
+
+```
+┌─────────────────┐   POST /v1.0/publish/...    ┌────────────────┐
+│ heartbeat-tick  │ ──────────────────────────► │ daprd-heartbeat│
+│  (this service) │                              │   (sidecar)    │
+└─────────────────┘                              └────────────────┘
+                                                         │
+                                  pubsub.jetstream       │
+                                                         ▼
+                            ┌────────────────────────────────────┐
+                            │ NATS subject event.system.heartbeat │
+                            │ stream BLOODBANK_V3_EVENTS          │
+                            └────────────────────────────────────┘
+                                                         │
+                                                 Dapr delivers
+                                                         ▼
+                                  ┌────────────────────────────────┐
+                                  │ POST /events/heartbeat         │
+                                  │ heartbeat-recorder app         │
+                                  └────────────────────────────────┘
+```
+
+A single `daprd-heartbeat` sidecar serves both sides: heartbeat-tick
+publishes to its HTTP API, heartbeat-recorder is wired as the
+`--app-port` consumer.
+
+## Schema
+
+Defined in [Holyfields](../../../holyfields/schemas/system/heartbeat.tick.v1.json).
+Extends `_common/cloudevent_base.v1.json`. Required `data` fields:
+
+| field | type | purpose |
+|---|---|---|
+| `tick_seq` | int | Monotonic counter from this producer instance |
+| `producer_id` | string | Stable per-instance identity (logs / dedup) |
+| `started_at` | RFC3339 | Producer instance start time (restart detection) |
+| `interval_ms` | int (≥100) | Configured tick interval (advisory) |
+
+The service constructs the envelope as a JSON dict directly. Switching
+to the Holyfields-generated Pydantic model is a follow-up once the
+Holyfields installable-package story is stable inside containers.
+
+## Configuration (env vars)
+
+| var | default | purpose |
+|---|---|---|
+| `DAPR_HTTP_HOST` | `daprd-heartbeat` | Sidecar host on compose network |
+| `DAPR_HTTP_PORT` | `3500` | Sidecar HTTP port |
+| `DAPR_PUBSUB` | `bloodbank-v3-pubsub` | Dapr pubsub component |
+| `HEARTBEAT_TOPIC` | `event.system.heartbeat.tick` | Topic = NATS subject |
+| `HEARTBEAT_INTERVAL` | `5` | Tick interval (seconds) |
+| `PRODUCER_ID` | `heartbeat-tick:<random>` | Stable per-instance id |
+| `LOG_LEVEL` | `INFO` | Standard Python logging level |
+
+## Running
+
+The compose `heartbeat` profile brings up everything:
+
+```bash
+docker compose --project-name bloodbank-v3 \
+  --profile heartbeat \
+  -f compose/v3/docker-compose.yml \
+  up -d nats nats-init dapr-placement \
+        heartbeat-recorder daprd-heartbeat heartbeat-tick
+```
+
+Verify ticks landed:
+
+```bash
+curl http://127.0.0.1:3601/inspect/recorded | jq '.count, .producers'
+```
+
+Run the integration smoke test:
+
+```bash
+bash ops/v3/smoketest/smoketest-heartbeat.sh
+```
+
+## Observability hooks
+
+heartbeat-tick logs every successful publish: `emitted tick_seq=N id=...`.
+On publish failure it logs at WARNING but does not crash; consumers
+detect the gap via `tick_seq` stalling.
+
+## Why this is "real"
+
+Unlike the smoketest scripts under `ops/v3/smoketest/` which run
+ephemerally and prove transport, this is a production-shape service:
+
+- Long-running container (not a CI-spawned ephemeral)
+- Builds CloudEvents envelopes that match the canonical schema
+- Handles SIGTERM with drain semantics
+- Runs as non-root in the image
+- Tolerates daprd boot races
+- Real consumer side (heartbeat-recorder) with persistent buffer + summary
+
+It is the pattern reference for every future v3 service.

--- a/services/heartbeat-tick/main.py
+++ b/services/heartbeat-tick/main.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Heartbeat tick producer — first real-world v3 event publisher.
+
+Long-running service that emits `system.heartbeat.tick` events through
+Dapr pub/sub on a configurable interval. Each tick carries a monotonic
+sequence number, an instance-stable producer_id, and the producer's
+start time so consumers can detect restarts.
+
+Schema: holyfields/schemas/system/heartbeat.tick.v1.json (extends
+cloudevent_base.v1.json). This service constructs the envelope as a
+JSON dict directly; switching to the Holyfields-generated Pydantic
+model is a follow-up once the holyfields installable-package story is
+stable inside containers.
+
+Configuration via env vars:
+  DAPR_HTTP_HOST       Hostname of the daprd sidecar (default: daprd-heartbeat)
+  DAPR_HTTP_PORT       Port of the daprd HTTP API (default: 3500)
+  DAPR_PUBSUB          Dapr pubsub component name (default: bloodbank-v3-pubsub)
+  HEARTBEAT_INTERVAL   Tick interval in seconds (default: 5)
+  HEARTBEAT_TOPIC      Dapr topic / NATS subject (default: event.system.heartbeat.tick)
+  PRODUCER_ID          Stable per-instance id (default: heartbeat-tick:<random>)
+  LOG_LEVEL            INFO / DEBUG (default: INFO)
+
+Stdlib only (urllib + json) so the container image stays minimal.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+LOG = logging.getLogger("heartbeat-tick")
+
+
+def _now_iso() -> str:
+    """RFC3339 UTC timestamp matching the heartbeat schema's `time` field."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def build_envelope(*, tick_seq: int, producer_id: str, started_at: str, interval_ms: int) -> dict:
+    """Construct a CloudEvents 1.0 envelope matching system.heartbeat.tick.v1."""
+    return {
+        "specversion": "1.0",
+        "id": str(uuid.uuid4()),
+        "source": "urn:33god:service:heartbeat-tick",
+        "type": "system.heartbeat.tick",
+        "subject": f"system/{producer_id}",
+        "time": _now_iso(),
+        "datacontenttype": "application/json",
+        "dataschema": "apicurio://holyfields/system.heartbeat.tick/versions/1",
+        "correlationid": str(uuid.uuid4()),
+        "causationid": None,
+        "producer": "heartbeat-tick",
+        "service": "heartbeat-tick",
+        "domain": "system",
+        "schemaref": "system.heartbeat.tick.v1",
+        "traceparent": "00-00000000000000000000000000000000-0000000000000000-00",
+        "data": {
+            "tick_seq": tick_seq,
+            "interval_ms": interval_ms,
+            "producer_id": producer_id,
+            "started_at": started_at,
+        },
+    }
+
+
+def publish(dapr_url: str, pubsub: str, topic: str, envelope: dict, timeout: float = 5.0) -> None:
+    """POST the envelope to Dapr pub/sub. Raises on non-2xx."""
+    url = f"{dapr_url}/v1.0/publish/{pubsub}/{topic}"
+    body = json.dumps(envelope).encode("utf-8")
+    req = urllib_request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/cloudevents+json"},
+        method="POST",
+    )
+    with urllib_request.urlopen(req, timeout=timeout) as resp:
+        if resp.status >= 300:
+            raise RuntimeError(f"dapr publish returned HTTP {resp.status}")
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+_running = True
+
+
+def _handle_signal(signum: int, _frame: object) -> None:
+    global _running
+    LOG.info("received signal %d; draining and exiting", signum)
+    _running = False
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    dapr_host = os.environ.get("DAPR_HTTP_HOST", "daprd-heartbeat")
+    dapr_port = os.environ.get("DAPR_HTTP_PORT", "3500")
+    dapr_url = f"http://{dapr_host}:{dapr_port}"
+    pubsub = os.environ.get("DAPR_PUBSUB", "bloodbank-v3-pubsub")
+    topic = os.environ.get("HEARTBEAT_TOPIC", "event.system.heartbeat.tick")
+    interval_s = float(os.environ.get("HEARTBEAT_INTERVAL", "5"))
+    interval_ms = int(interval_s * 1000)
+
+    producer_id = os.environ.get(
+        "PRODUCER_ID", f"heartbeat-tick:{uuid.uuid4().hex[:8]}"
+    )
+    started_at = _now_iso()
+
+    LOG.info(
+        "starting heartbeat-tick: dapr=%s pubsub=%s topic=%s interval=%.2fs producer_id=%s",
+        dapr_url, pubsub, topic, interval_s, producer_id,
+    )
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    # Wait for daprd to come up before first publish. Boot races are real;
+    # we tolerate up to 60s of "connection refused" before giving up.
+    deadline = time.monotonic() + 60.0
+    while _running and time.monotonic() < deadline:
+        try:
+            with urllib_request.urlopen(f"{dapr_url}/v1.0/healthz", timeout=2.0) as resp:
+                if resp.status in (200, 204):
+                    LOG.info("daprd healthy")
+                    break
+        except (urllib_error.URLError, ConnectionError, TimeoutError) as exc:
+            LOG.debug("daprd not yet ready: %s", exc)
+        time.sleep(2)
+    else:
+        if not _running:
+            return 0
+        LOG.error("daprd never became healthy at %s", dapr_url)
+        return 1
+
+    tick_seq = 0
+    while _running:
+        envelope = build_envelope(
+            tick_seq=tick_seq,
+            producer_id=producer_id,
+            started_at=started_at,
+            interval_ms=interval_ms,
+        )
+        try:
+            publish(dapr_url, pubsub, topic, envelope)
+            LOG.info("emitted tick_seq=%d id=%s", tick_seq, envelope["id"])
+            tick_seq += 1
+        except Exception as exc:
+            # Don't crash the loop on transient publish failures; let CI
+            # / observability surface it through tick_seq stalling.
+            LOG.warning("publish failed (tick_seq=%d): %s", tick_seq, exc)
+
+        # Sleep in small chunks so SIGTERM is responsive (no 5-30s delay
+        # to drain on shutdown).
+        slept = 0.0
+        while _running and slept < interval_s:
+            chunk = min(0.5, interval_s - slept)
+            time.sleep(chunk)
+            slept += chunk
+
+    LOG.info("heartbeat-tick exiting; final tick_seq=%d", tick_seq - 1)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The first real domain event flowing through the v3 platform end-to-end. Long-running producer + subscriber app + Dapr sidecar + JetStream stream + new integration smoke test, all gated by CI.

Companion to [holyfields PR #4](https://github.com/delorenj/holyfields/pull/4) (already merged) which defined `system.heartbeat.tick.v1`.

## What's new

| File | Purpose |
|---|---|
| `services/heartbeat-tick/` | stdlib-only Python publisher, 5s interval default, monotonic tick_seq, drain on SIGTERM |
| `services/heartbeat-recorder/` | stdlib-only subscriber app, /inspect hooks, per-producer summary |
| `compose/v3/docker-compose.yml` | new `heartbeat` profile (3 services: tick + recorder + daprd-heartbeat) |
| `compose/v3/nats/init.sh` | race fix (see below) |
| `ops/v3/smoketest/smoketest-heartbeat.sh` | integration test asserting tick count + monotonic invariants |
| `.github/workflows/ci.yml` | new heartbeat layer in CI smoke job |

## Bug caught + fixed during integration

**JetStream metadata propagation race.** nats-init created streams successfully and exited 0, but Dapr's pubsub.jetstream component connecting in the next ~hundred-ms window hit `nats: stream not found` on its initial subscribe binding. The race was noted in earlier adversarial reviews for daprd-subscribe and worked around with manual restart. Now fixed at the root: nats-init verifies every stream is queryable from a fresh `nats stream info` call before exiting.

## Live validation (single fresh boot, race fix in place)

```
smoketest.sh                  PASS
smoketest-command.sh          PASS
smoketest-heartbeat.sh        PASS  (2 ticks, monotonic, single producer)
```

heartbeat-tick log over 70s confirms production-shape behavior:
```
emitted tick_seq=0 id=...
emitted tick_seq=1 id=...
emitted tick_seq=2 id=...
... (no gaps, no panics, daprd health-wait succeeded)
```

## Why this is "real"

Unlike the smoke test scripts that publish ephemerally and prove transport, this is a **production-shape service**:

- Long-running container (not a CI-spawned ephemeral)
- Real CloudEvents envelopes matching the Holyfields-canonical schema
- SIGTERM drain semantics
- Non-root container
- 60s daprd health-wait before first publish
- Tolerates transient publish failures (logs warning; consumers detect via tick_seq stalling)
- Per-producer monotonicity invariant verified end-to-end

It is the **pattern reference for every future v3 service**.

## Honest follow-ups (not blockers)

- Switch heartbeat-tick from hand-built dict to the Holyfields-generated Pydantic model once the holyfields-as-installable-package story works inside containers (currently we'd need build context above bloodbank/ to COPY holyfields)
- Document the per-service AsyncAPI convention now that the first service exists to anchor the pattern (ADR-0002 follow-up)

## Test plan

- [ ] CI runs all five smoke tests including new heartbeat layer; all PASS
- [ ] `bash ops/v3/smoketest/smoketest-heartbeat.sh` succeeds locally after `up`
- [ ] No `nats: stream not found` on first boot (race fix)
- [ ] Producer summary in `/inspect/recorded` shows `count == last_tick_seq - first_tick_seq + 1` (no gaps)