### PR TITLE
feat(claude-events): subscribe to 3 more agent.* event types (GOD-43 V3-109)

### DIFF
--- a/ops/v3/smoketest/smoketest-claude-events.sh
+++ b/ops/v3/smoketest/smoketest-claude-events.sh
@@ -3,10 +3,9 @@
 # Bloodbank v3 claude-events round-trip smoke test.
 #
 # Verifies that synthetic agent.* envelopes published through the
-# claude-events daprd sidecar land on the recorder for all three event
-# types. This is the smoke gate for V3-108 (dedicated profile + recorder)
-# and the on-host equivalent of what `.claude/hooks/bloodbank-publisher.sh`
-# does at runtime.
+# claude-events daprd sidecar land on the recorder for all six event
+# types we currently emit. Smoke gate for V3-108 (profile + recorder)
+# and V3-109 (additional hook events).
 #
 # Pipeline under test:
 #
@@ -18,8 +17,10 @@
 #               → /inspect/recorded
 #
 # Assertions:
-#   - All three event types appear in count_by_type
-#   - Per-session aggregate shows started=true, ended=true, tool_invocations>=1
+#   - All six event types appear in count_by_type with count >= 1
+#   - Per-session aggregate shows full lifecycle for the synthetic
+#     session (started, ended, prompts_submitted >= 1, tool_requests >= 1,
+#     tool_invocations >= 1, subagents_completed >= 1)
 #   - Each envelope is shape-valid CloudEvents 1.0 with the expected `type`
 #
 # Preconditions (caller responsibility):
@@ -27,8 +28,14 @@
 #     -f compose/v3/docker-compose.yml \
 #     up -d nats nats-init dapr-placement claude-events-recorder daprd-claude-events
 #
+# Optional env:
+#   SESSION_ID  override the synthetic session_id (default: random uuid).
+#               useful for the human verification runlist where the
+#               operator wants a pre-known id to filter on.
+#
 # Usage:
 #   bash ops/v3/smoketest/smoketest-claude-events.sh
+#   SESSION_ID=verify-synth-1 bash ops/v3/smoketest/smoketest-claude-events.sh
 #
 # Exit codes:
 #   0 — PASS
@@ -40,7 +47,7 @@ set -euo pipefail
 DAPR_HTTP="${DAPR_HTTP:-http://127.0.0.1:3503}"
 RECORDER_HTTP="${RECORDER_HTTP:-http://127.0.0.1:3602}"
 PUBSUB="${PUBSUB:-bloodbank-v3-pubsub}"
-WAIT_SECONDS=10
+WAIT_SECONDS=15
 
 fail() { local rc="$1"; shift; echo "smoketest-claude-events: FAIL -- $*" >&2; exit "${rc}"; }
 
@@ -66,10 +73,11 @@ curl -sS -X POST "${RECORDER_HTTP}/inspect/reset" >/dev/null \
 # -----------------------------------------------------------------------------
 # 3. Publish synthetic envelopes (one of each agent.* type, same session_id)
 # -----------------------------------------------------------------------------
-# Use python3 for envelope construction (jq lacks uuid + iso-now). Stdlib
-# only; no runtime deps assumed beyond the CI base image.
-SESSION_ID=$(python3 -c 'import uuid; print(uuid.uuid4())')
+# SESSION_ID is the synthetic session's id and the correlationid for every
+# envelope in this run. Allows the runlist to filter by `data.session_id`.
+SESSION_ID="${SESSION_ID:-$(python3 -c 'import uuid; print(uuid.uuid4())')}"
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+echo "smoketest-claude-events: session_id=${SESSION_ID}"
 
 publish_envelope() {
   local ev_type="$1" topic="$2" data="$3"
@@ -108,17 +116,29 @@ print(json.dumps({
   fi
 }
 
+# Order matches a real session lifecycle: start, prompt, request, invoke,
+# subagent finishes, end. Recorder doesn't rely on order; ordering here is
+# for human readability of the test trace.
 publish_envelope "agent.session.started" "event.agent.session.started" \
   "{\"session_id\":\"${SESSION_ID}\",\"working_directory\":\"/tmp/smoketest\",\"git_branch\":\"main\",\"git_remote\":\"\",\"started_at\":\"${NOW}\"}"
 
+publish_envelope "agent.prompt.submitted" "event.agent.prompt.submitted" \
+  "{\"session_id\":\"${SESSION_ID}\",\"prompt_text\":\"list .claude/hooks\",\"prompt_length\":18,\"working_directory\":\"/tmp/smoketest\",\"git_branch\":\"main\"}"
+
+publish_envelope "agent.tool.requested" "event.agent.tool.requested" \
+  "{\"session_id\":\"${SESSION_ID}\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls .claude/hooks\"},\"working_directory\":\"/tmp/smoketest\",\"git_branch\":\"main\",\"turn_number\":1}"
+
 publish_envelope "agent.tool.invoked" "event.agent.tool.invoked" \
-  "{\"session_id\":\"${SESSION_ID}\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo hi\"},\"working_directory\":\"/tmp/smoketest\",\"git_branch\":\"main\",\"git_status\":\"clean\",\"turn_number\":1,\"success\":true}"
+  "{\"session_id\":\"${SESSION_ID}\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls .claude/hooks\"},\"working_directory\":\"/tmp/smoketest\",\"git_branch\":\"main\",\"git_status\":\"clean\",\"turn_number\":1,\"success\":true}"
+
+publish_envelope "agent.subagent.completed" "event.agent.subagent.completed" \
+  "{\"session_id\":\"${SESSION_ID}\",\"agent_type\":\"general-purpose\",\"stop_reason\":\"completed\",\"working_directory\":\"/tmp/smoketest\"}"
 
 publish_envelope "agent.session.ended" "event.agent.session.ended" \
   "{\"session_id\":\"${SESSION_ID}\",\"end_reason\":\"user_stop\",\"duration_seconds\":42,\"total_turns\":1,\"tools_used\":{\"Bash\":1},\"files_modified\":[],\"git_commits\":[],\"final_status\":\"success\",\"working_directory\":\"/tmp/smoketest\",\"git_branch\":\"main\"}"
 
 # -----------------------------------------------------------------------------
-# 4. Wait for delivery (Dapr → app callback)
+# 4. Wait for delivery
 # -----------------------------------------------------------------------------
 deadline=$(( $(date +%s) + WAIT_SECONDS ))
 final_count=0
@@ -126,17 +146,17 @@ while [[ $(date +%s) -lt ${deadline} ]]; do
   count=$(curl -sS --max-time 3 "${RECORDER_HTTP}/inspect/recorded" 2>/dev/null \
     | python3 -c "import json,sys; print(json.load(sys.stdin)['count'])" 2>/dev/null \
     || echo 0)
-  if [[ "${count}" -ge 3 ]]; then
+  if [[ "${count}" -ge 6 ]]; then
     final_count="${count}"
     break
   fi
   sleep 1
 done
 
-if [[ "${final_count}" -lt 3 ]]; then
+if [[ "${final_count}" -lt 6 ]]; then
   echo "Recorder dump:"
   curl -sS "${RECORDER_HTTP}/inspect/recorded" | python3 -m json.tool >&2 || true
-  fail 1 "expected 3 envelopes, got ${final_count} after ${WAIT_SECONDS}s"
+  fail 1 "expected 6 envelopes, got ${final_count} after ${WAIT_SECONDS}s"
 fi
 
 # -----------------------------------------------------------------------------
@@ -154,8 +174,16 @@ envelopes = data.get('envelopes', [])
 count_by_type = data.get('count_by_type', {})
 sessions = data.get('sessions', [])
 
-# 1. count_by_type covers all three
-for t in ('agent.session.started', 'agent.session.ended', 'agent.tool.invoked'):
+# 1. count_by_type covers all six
+expected_types = (
+    'agent.session.started',
+    'agent.session.ended',
+    'agent.tool.invoked',
+    'agent.prompt.submitted',
+    'agent.tool.requested',
+    'agent.subagent.completed',
+)
+for t in expected_types:
     if count_by_type.get(t, 0) < 1:
         problems.append(f'count_by_type missing or zero for {t}')
 
@@ -169,12 +197,20 @@ for i, env in enumerate(envelopes):
     if env.get('domain') != 'agent':
         problems.append(f\"envelope[{i}] domain = {env.get('domain')!r}\")
 
-# 3. Per-session aggregate
+# 3. Per-session aggregate covers full new shape
 matching = [s for s in sessions if s.get('session_id') == session_id]
 if len(matching) != 1:
     problems.append(f'expected exactly one session entry for {session_id}, got {len(matching)}')
-elif not (matching[0].get('started') and matching[0].get('ended') and matching[0].get('tool_invocations', 0) >= 1):
-    problems.append(f'session aggregate incomplete: {matching[0]}')
+else:
+    s = matching[0]
+    for required_truthy in ('started', 'ended'):
+        if not s.get(required_truthy):
+            problems.append(f'session aggregate {required_truthy} should be true: {s}')
+    for required_count in ('prompts_submitted', 'tool_requests', 'tool_invocations', 'subagents_completed'):
+        if s.get(required_count, 0) < 1:
+            problems.append(f'session aggregate {required_count} should be >= 1: {s}')
+    if 'last_seen' not in s:
+        problems.append(f'session aggregate missing last_seen: {s}')
 
 if problems:
     print('claude-events smoke validation failed:', file=sys.stderr)

--- a/services/claude-events-recorder/README.md
+++ b/services/claude-events-recorder/README.md
@@ -24,15 +24,18 @@ in-memory buffer + per-session aggregate
 
 ## Subscriptions
 
-The recorder declares three programmatic subscriptions (no wildcard);
-each agent.* event type gets its own route. This keeps the contract
-explicit and matches the publisher's topic choices 1:1.
+The recorder declares one programmatic subscription per agent.* event
+type. Explicit routes (no wildcard) keep the contract debuggable and
+match the publisher's topic choices 1:1.
 
 | CloudEvents `type` | NATS subject | Route |
 |---|---|---|
-| `agent.session.started` | `event.agent.session.started` | `/events/session_started` |
-| `agent.session.ended`   | `event.agent.session.ended`   | `/events/session_ended`   |
-| `agent.tool.invoked`    | `event.agent.tool.invoked`    | `/events/tool_invoked`    |
+| `agent.session.started`  | `event.agent.session.started`  | `/events/session_started`  |
+| `agent.session.ended`    | `event.agent.session.ended`    | `/events/session_ended`    |
+| `agent.prompt.submitted` | `event.agent.prompt.submitted` | `/events/prompt_submitted` |
+| `agent.tool.requested`   | `event.agent.tool.requested`   | `/events/tool_requested`   |
+| `agent.tool.invoked`     | `event.agent.tool.invoked`     | `/events/tool_invoked`     |
+| `agent.subagent.completed` | `event.agent.subagent.completed` | `/events/subagent_completed` |
 
 ## Inspection endpoints
 
@@ -45,8 +48,24 @@ explicit and matches the publisher's topic choices 1:1.
 | POST | `/events/...`        | Dapr delivery — internal, not for direct callers |
 
 The `sessions` array contains a per-session aggregate so tests can
-assert lifecycle (`started`, `ended`, `tool_invocations`) without
-walking the envelope buffer.
+assert lifecycle without walking the envelope buffer:
+
+```json
+{
+  "session_id": "...",
+  "started": true,
+  "ended": true,
+  "tool_invocations": 4,
+  "tool_requests": 4,
+  "prompts_submitted": 2,
+  "subagents_completed": 1,
+  "last_seen": "2026-04-29T08:01:23Z",
+  "first_seen_type": "agent.session.started",
+  "working_directory": "...",
+  "git_branch": "...",
+  "end_reason": "user_stop"
+}
+```
 
 ## Configuration (env vars)
 

--- a/services/claude-events-recorder/main.py
+++ b/services/claude-events-recorder/main.py
@@ -59,11 +59,29 @@ SUBSCRIPTIONS: list[dict] = [
         "topic": "event.agent.tool.invoked",
         "route": "/events/tool_invoked",
     },
+    {
+        "pubsubname": SUBSCRIBE_PUBSUB,
+        "topic": "event.agent.prompt.submitted",
+        "route": "/events/prompt_submitted",
+    },
+    {
+        "pubsubname": SUBSCRIBE_PUBSUB,
+        "topic": "event.agent.tool.requested",
+        "route": "/events/tool_requested",
+    },
+    {
+        "pubsubname": SUBSCRIBE_PUBSUB,
+        "topic": "event.agent.subagent.completed",
+        "route": "/events/subagent_completed",
+    },
 ]
 ROUTE_TO_TYPE: dict[str, str] = {
     "/events/session_started": "agent.session.started",
     "/events/session_ended": "agent.session.ended",
     "/events/tool_invoked": "agent.tool.invoked",
+    "/events/prompt_submitted": "agent.prompt.submitted",
+    "/events/tool_requested": "agent.tool.requested",
+    "/events/subagent_completed": "agent.subagent.completed",
 }
 
 _lock = threading.Lock()
@@ -90,8 +108,16 @@ def _record(envelope: dict) -> None:
             "started": False,
             "ended": False,
             "tool_invocations": 0,
+            "tool_requests": 0,
+            "prompts_submitted": 0,
+            "subagents_completed": 0,
             "first_seen_type": ev_type,
         }
+        # Track event time so test runlists can sort by recency.
+        env_time = envelope.get("time")
+        if isinstance(env_time, str):
+            entry["last_seen"] = env_time
+
         if ev_type == "agent.session.started":
             entry["started"] = True
             entry["working_directory"] = data.get("working_directory")
@@ -103,6 +129,12 @@ def _record(envelope: dict) -> None:
             entry["total_turns"] = data.get("total_turns")
         elif ev_type == "agent.tool.invoked":
             entry["tool_invocations"] += 1
+        elif ev_type == "agent.tool.requested":
+            entry["tool_requests"] += 1
+        elif ev_type == "agent.prompt.submitted":
+            entry["prompts_submitted"] += 1
+        elif ev_type == "agent.subagent.completed":
+            entry["subagents_completed"] += 1
         _sessions[sid] = entry
 
 


### PR DESCRIPTION
## Summary

Extends `claude-events-recorder` to cover the three additional `agent.*` event types shipping in this wave. Companion to the holyfields schema PR and the metarepo publisher PR.

### What changes

**Recorder** (`services/claude-events-recorder/main.py`)
- Three new programmatic subscriptions / routes:
  - `agent.prompt.submitted` → `/events/prompt_submitted`
  - `agent.tool.requested` → `/events/tool_requested`
  - `agent.subagent.completed` → `/events/subagent_completed`
- Per-session aggregate gains `tool_requests`, `prompts_submitted`, `subagents_completed` counters plus `last_seen` timestamp (lets runlists sort sessions by recency without scanning the buffer).

**Smoke test** (`ops/v3/smoketest/smoketest-claude-events.sh`)
- Now publishes 6 envelopes (one per type) for a single synthetic session, asserts all 6 land, all 6 lifecycle counters >= 1.
- Honors a `SESSION_ID` env var override so the human verification runlist can pre-pick a filter key.

### Verified locally

```
$ SESSION_ID=verify-synth-test-1 bash ops/v3/smoketest/smoketest-claude-events.sh
smoketest-claude-events: session_id=verify-synth-test-1
OK: 6 envelopes across 6 types, session aggregate complete
smoketest-claude-events: PASS

# recorder shape:
sessions: [{
  session_id: 'verify-synth-test-1',
  started: True, ended: True,
  tool_invocations: 1, tool_requests: 1,
  prompts_submitted: 1, subagents_completed: 1,
  last_seen: '2026-04-29T15:31:54Z',
  ...
}]
```

## Test plan

- [x] Smoke test passes locally (6 envelopes, all aggregate counters)
- [x] Per-session `last_seen` timestamp populates from envelope `time` field
- [x] Existing 3-type integration unaffected
- [x] `force-recreate` is the right docker compose flag for picking up code changes (footgun documented in commit chain)