### PR TITLE
ci: temporary non-blocking fallback for claude-review failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
Temporarily make the Claude Code Review step non-blocking to prevent unrelated PRs from getting stuck on the known upstream action/runtime failure mode.

## Why
Issue #34 tracks recurring failures in `anthropics/claude-code-action` (`ENOENT symlink` / `directory mismatch ... tsconfig.json`) that are not caused by repository code.

## Changes
- Add `continue-on-error: true` to the `Run Claude Code Review` step in `.github/workflows/claude-code-review.yml`.

## Follow-up
- Keep #34 open to implement a stronger long-term fix (pinning/upgrade policy or conditional retry strategy).

Closes #34