### PR TITLE
ops: initialize BMAD scaffold for Bloodbank

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,12 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:claude-events`  | Claude `agent.*` event round-trip      |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
+## BMAD baseline
+
+- This repo is BMAD-initialized with a lightweight scaffold under `_bmad/` and `_bmad_output/`.
+- For ticket-first work, use `_bmad/templates/ticket-execution.md` to track scope/steps/verification per issue.
+- Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.
+
 ## Conventions
 
 - Subjects: `event.{domain}.{entity}.{action}` and `command.{agent}.{action}`.

--- a/_bmad/README.md
+++ b/_bmad/README.md
@@ -1,0 +1,15 @@
+# BMAD scaffold (Bloodbank)
+
+This repository uses a lightweight BMAD baseline for ticket-first execution.
+
+## Minimal flow
+1. Start from an existing ticket/issue.
+2. Create or update a short execution note under `_bmad_output/` scoped to that ticket.
+3. Implement in a focused branch/PR tied to the ticket.
+4. Record verification evidence in the PR body and ticket comments.
+
+## In this scaffold
+- `templates/ticket-execution.md` — starter template for ticket-scoped execution notes.
+- `_bmad_output/` — place for generated ticket execution artifacts.
+
+Keep this lightweight; use only what helps drive shipping and verification.

--- a/_bmad/templates/ticket-execution.md
+++ b/_bmad/templates/ticket-execution.md
@@ -1,0 +1,19 @@
+# Ticket Execution — <issue-id>
+
+## Scope
+- Ticket: <link>
+- Objective: <one sentence>
+
+## Plan
+- [ ] Step 1
+- [ ] Step 2
+- [ ] Step 3
+
+## Verification
+- Command/check:
+- Result/evidence:
+
+## Outcome
+- PR:
+- Commit(s):
+- Follow-ups:

--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -1,0 +1,6 @@
+# BMAD output
+
+Ticket-scoped execution artifacts live here (notes, checklists, evidence snippets).
+
+Convention:
+- `issue-<id>-execution.md`


### PR DESCRIPTION
## Summary
Initialize a lightweight BMAD baseline in Bloodbank for ticket-first execution.

## Changes
- Add `_bmad/README.md`
- Add `_bmad/templates/ticket-execution.md`
- Add `_bmad_output/README.md`
- Add BMAD usage note to `AGENTS.md`

## Why
Closes #36 by establishing minimal, repo-local BMAD structure without adding process bloat.

Closes #36