### PR TITLE
ops: define BMAD closeout artifact standard

### DIFF
--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -2,5 +2,14 @@
 
 Ticket-scoped execution artifacts live here (notes, checklists, evidence snippets).
 
-Convention:
-- `issue-<id>-execution.md`
+## Closeout artifact convention
+
+For every completed ticket, add one closeout file:
+- Path: `_bmad_output/issue-<id>-execution.md`
+- Starter template: `_bmad_output/templates/ticket-closeout.md`
+
+Required fields:
+- Ticket id + title
+- Scope completed (what changed / what did not)
+- Verification evidence (commands/checks and outcomes)
+- Links to issue + PR (and follow-ups if any)

--- a/_bmad_output/templates/ticket-closeout.md
+++ b/_bmad_output/templates/ticket-closeout.md
@@ -1,0 +1,25 @@
+# Issue <id> — execution closeout
+
+## Ticket
+- Issue: #<id>
+- Title: <title>
+- Owner: <name/agent>
+
+## Scope completed
+- <change 1>
+- <change 2>
+
+## Out of scope
+- <explicitly deferred item or `none`>
+
+## Verification evidence
+- `<command/check>` → <result>
+- `<command/check>` → <result>
+
+## Links
+- Issue: <url>
+- PR: <url>
+- Follow-up tickets: <none | #id, #id>
+
+## Notes
+- <risks, caveats, or `none`>


### PR DESCRIPTION
## Summary
Add a lightweight closeout convention for BMAD ticket execution artifacts.

## Changes
- Expand `_bmad_output/README.md` with required closeout fields.
- Add `_bmad_output/templates/ticket-closeout.md` starter template.

## Why
Closes #38 by making ticket completion evidence consistent and auditable without adding process bloat.

Closes #38