### PR TITLE
docs: add BMAD closeout artifact index

### DIFF
--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -13,3 +13,10 @@ Required fields:
 - Scope completed (what changed / what did not)
 - Verification evidence (commands/checks and outcomes)
 - Links to issue + PR (and follow-ups if any)
+
+## Closeout artifact index
+
+- `issue-38-execution.md` — closes out #38 via PR #39 (BMAD closeout standard)
+
+Index append convention (for each new closeout file):
+- `issue-<id>-execution.md` — closes out #<id> via PR #<pr> (<short scope note>)


### PR DESCRIPTION
## Summary
Add a lightweight index for BMAD closeout artifacts.

## Changes
- Add `Closeout artifact index` section to `_bmad_output/README.md`.
- List existing artifact `issue-38-execution.md`.
- Add one-line append convention for future entries.

## Why
Closes #42 by making closeout evidence discoverable and consistent without adding process bloat.

Closes #42
