### PR TITLE
docs: align BMAD flow doc with closeout conventions

### DIFF
--- a/_bmad/README.md
+++ b/_bmad/README.md
@@ -4,12 +4,14 @@ This repository uses a lightweight BMAD baseline for ticket-first execution.
 
 ## Minimal flow
 1. Start from an existing ticket/issue.
-2. Create or update a short execution note under `_bmad_output/` scoped to that ticket.
-3. Implement in a focused branch/PR tied to the ticket.
-4. Record verification evidence in the PR body and ticket comments.
+2. Draft scope with `templates/ticket-execution.md` (or update an existing ticket note).
+3. Implement in a focused branch/PR tied to that ticket.
+4. On completion, add/update `_bmad_output/issue-<id>-execution.md` as the closeout artifact.
+5. Ensure closeout evidence quality and index entry follow `_bmad_output/README.md`.
 
 ## In this scaffold
 - `templates/ticket-execution.md` — starter template for ticket-scoped execution notes.
-- `_bmad_output/` — place for generated ticket execution artifacts.
+- `_bmad_output/` — ticket closeout artifacts (`issue-<id>-execution.md`).
+- `_bmad_output/README.md` — source of truth for closeout index + verification checklist expectations.
 
 Keep this lightweight; use only what helps drive shipping and verification.


### PR DESCRIPTION
## Summary
Align `_bmad/README.md` minimal flow with current closeout conventions.

## Changes
- Update minimal flow to include explicit closeout artifact step (`_bmad_output/issue-<id>-execution.md`).
- Reference `_bmad_output/README.md` as source of truth for index + verification checklist expectations.
- Keep guidance concise and ticket-first.

## Why
Closes #46 by keeping BMAD onboarding docs consistent with the closeout template/index/checklist already established.

Closes #46
