### PR TITLE
docs: add BMAD quickstart pointer to AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ alongside each service, using Holyfields-generated publishers.
 ## BMAD baseline
 
 - This repo is BMAD-initialized with a lightweight scaffold under `_bmad/` and `_bmad_output/`.
+- Quickstart: read `_bmad/README.md` for ticket execution flow, then `_bmad_output/README.md` for closeout index + verification checklist expectations.
 - For ticket-first work, use `_bmad/templates/ticket-execution.md` to track scope/steps/verification per issue.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.
 


### PR DESCRIPTION
## Summary
Add a concise BMAD quickstart pointer to the root agent guide.

## Changes
- Update `AGENTS.md` BMAD baseline section with quickstart pointers to:
  - `_bmad/README.md` (ticket execution flow)
  - `_bmad_output/README.md` (closeout index + verification checklist)

## Why
Closes #48 by improving discoverability of BMAD execution/closeout guidance from the primary repo onboarding doc.

Closes #48
