### PR TITLE
docs: add BMAD CI-failure triage note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,10 @@ alongside each service, using Holyfields-generated publishers.
   - issue URL
   - merged PR URL
   - `_bmad_output/issue-<id>-execution.md` artifact path
+- CI-failure triage (when a PR check goes red): capture a minimal evidence loop before next action:
+  - failing check run URL
+  - `gh run view <run-id> --log-failed` excerpt (error signature)
+  - follow-up ticket URL when the fix is out of current PR scope
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.
 
 ## Conventions


### PR DESCRIPTION
## Summary
Add a concise BMAD CI-failure triage note to the root agent guide.

## Changes
- Update `AGENTS.md` BMAD section with a minimal triage evidence loop for failing checks:
  - failing check run URL
  - `gh run view <run-id> --log-failed` excerpt
  - follow-up ticket URL when remediation is out of current PR scope

## Why
Closes #52 by making failed-check handling explicit while keeping process overhead lightweight.

Closes #52
