### PR TITLE
docs: add BMAD done-checklist to ticket template

### DIFF
--- a/_bmad/templates/ticket-execution.md
+++ b/_bmad/templates/ticket-execution.md
@@ -17,3 +17,8 @@
 - PR:
 - Commit(s):
 - Follow-ups:
+
+## Done checklist (closure hygiene)
+- [ ] Issue URL captured
+- [ ] Merged PR URL captured
+- [ ] Closeout artifact path captured (`_bmad_output/issue-<id>-execution.md`)


### PR DESCRIPTION
## Summary
Add a lightweight done-checklist to the BMAD ticket execution template.

## Changes
- Update `_bmad/templates/ticket-execution.md` with a closure hygiene checklist requiring:
  - issue URL
  - merged PR URL
  - closeout artifact path (`_bmad_output/issue-<id>-execution.md`)

## Why
Closes #54 by aligning ticket planning templates with established BMAD closure requirements.

Closes #54
