### PR TITLE
docs: add CI-failure triage block to BMAD ticket template

### DIFF
--- a/_bmad/templates/ticket-execution.md
+++ b/_bmad/templates/ticket-execution.md
@@ -13,6 +13,11 @@
 - Command/check:
 - Result/evidence:
 
+## CI failure triage (optional — only if checks fail)
+- Failing run URL:
+- Error signature excerpt (`gh run view <run-id> --log-failed`):
+- Follow-up ticket URL (if out of scope):
+
 ## Outcome
 - PR:
 - Commit(s):


### PR DESCRIPTION
## Summary
Add an optional CI-failure triage block to the BMAD ticket execution template.

## Changes
- Extend `_bmad/templates/ticket-execution.md` with an optional `CI failure triage` section.
- Capture fields for:
  - failing run URL
  - `gh run view <run-id> --log-failed` error signature excerpt
  - follow-up ticket URL when remediation is out of current PR scope

## Why
Closes #56 by allowing failed-check evidence to be captured directly in ticket execution notes with minimal overhead.

Closes #56
