### PR TITLE
ops: add mise task for bb repo-health snapshot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run up:all`       | Boot every profile (heartbeat + claude-events + Dapr smoke) |
 | `mise run down`         | Tear the sandbox down (`-v` removes volumes)     |
 | `mise run doctor`       | `cli/bb.py doctor` — manifest-driven scaffold check |
+| `mise run repo-health`  | `cli/bb.py repo-health` — read-only git/issue/PR/check snapshot |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/mise.toml
+++ b/mise.toml
@@ -34,6 +34,10 @@ docker compose --project-name $COMPOSE_PROJECT -f $COMPOSE_FILE \
 description = "Manifest-driven scaffold check (no Docker, no network)"
 run = "python3 cli/bb.py doctor"
 
+[tasks."repo-health"]
+description = "Read-only git/issue/PR/check snapshot for BMAD evidence"
+run = "python3 cli/bb.py repo-health"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"


### PR DESCRIPTION
## Summary
Add a `mise` task wrapper for `bb repo-health` to streamline BMAD evidence snapshots.

## Changes
- Add `tasks."repo-health"` in `mise.toml`:
  - `run = "python3 cli/bb.py repo-health"`
- Add one-line task mention in `AGENTS.md` mise task table.

## Verification
- `mise run repo-health`

## Why
Closes #60 by making repo-health evidence capture a one-command workflow from repo root.

Closes #60
