### PR TITLE
docs: document JSON repo-health usage for BMAD workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ alongside each service, using Holyfields-generated publishers.
   - failing check run URL
   - `gh run view <run-id> --log-failed` excerpt (error signature)
   - follow-up ticket URL when the fix is out of current PR scope
+- For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json`.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.
 
 ## Conventions

--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -29,3 +29,8 @@ Before marking a ticket closed, confirm the closeout artifact includes:
 - Links to the exact issue and PR URLs (not just numbers).
 - Any out-of-scope/deferred work called out explicitly (`none` when empty).
 - Notes section completed with risks/caveats or `none`.
+
+## Structured snapshot option (automation-friendly)
+
+Use JSON mode when evidence needs to be consumed by scripts/tools (artifact generators, dashboards, checks):
+- `python3 cli/bb.py repo-health --json`


### PR DESCRIPTION
## Summary
Document JSON-mode repo-health usage for BMAD evidence workflows.

## Changes
- Add scriptable evidence note to `AGENTS.md` BMAD guidance:
  - `python3 cli/bb.py repo-health --json`
- Add `Structured snapshot option (automation-friendly)` section to `_bmad_output/README.md` with the same command.

## Verification
- `python3 cli/bb.py repo-health --json`

## Why
Closes #64 by making structured evidence capture explicit in BMAD documentation.

Closes #64
