### PR TITLE
ops: add mise task for bb repo-health --json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run down`         | Tear the sandbox down (`-v` removes volumes)     |
 | `mise run doctor`       | `cli/bb.py doctor` — manifest-driven scaffold check |
 | `mise run repo-health`  | `cli/bb.py repo-health` — read-only git/issue/PR/check snapshot |
+| `mise run repo-health:json` | `cli/bb.py repo-health --json` — structured snapshot for scripts/tools |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/mise.toml
+++ b/mise.toml
@@ -38,6 +38,10 @@ run = "python3 cli/bb.py doctor"
 description = "Read-only git/issue/PR/check snapshot for BMAD evidence"
 run = "python3 cli/bb.py repo-health"
 
+[tasks."repo-health:json"]
+description = "Read-only structured JSON snapshot for BMAD/scripted evidence"
+run = "python3 cli/bb.py repo-health --json"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"


### PR DESCRIPTION
## Summary
Add a dedicated `mise` task for structured JSON repo-health snapshots.

## Changes
- Add `tasks."repo-health:json"` to `mise.toml`:
  - `python3 cli/bb.py repo-health --json`
- Add corresponding task entry in `AGENTS.md` mise task table.

## Verification
- `mise run repo-health:json`

## Why
Closes #66 by making script-friendly evidence capture a one-command workflow.

Closes #66
