### PR TITLE
ops: add repo-health:artifact mise task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run doctor`       | `cli/bb.py doctor` — manifest-driven scaffold check |
 | `mise run repo-health`  | `cli/bb.py repo-health` — read-only git/issue/PR/check snapshot |
 | `mise run repo-health:json` | `cli/bb.py repo-health --json` — structured snapshot for scripts/tools |
+| `mise run repo-health:artifact` | timestamped JSON evidence file under `_bmad_output/evidence/` |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/mise.toml
+++ b/mise.toml
@@ -42,6 +42,12 @@ run = "python3 cli/bb.py repo-health"
 description = "Read-only structured JSON snapshot for BMAD/scripted evidence"
 run = "python3 cli/bb.py repo-health --json"
 
+[tasks."repo-health:artifact"]
+description = "Write timestamped JSON BMAD evidence artifact under _bmad_output/evidence"
+run = """
+bash -lc 'ts=$(date -u +%Y%m%dT%H%M%SZ); out="_bmad_output/evidence/repo-health-${ts}.json"; python3 cli/bb.py repo-health --json --out "$out"; echo "$out"'
+"""
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"


### PR DESCRIPTION
## Summary
Add a one-command timestamped BMAD evidence snapshot task.

## Changes
- Add `tasks."repo-health:artifact"` to `mise.toml`.
- Task writes JSON repo-health output to:
  - `_bmad_output/evidence/repo-health-<utc-timestamp>.json`
- Document task in `AGENTS.md` mise task table.

## Verification
- `mise run repo-health:artifact`

## Why
Closes #70 by standardizing artifact naming/location for BMAD evidence capture.

Closes #70
