### PR TITLE
docs: document repo-health:artifact closeout workflow

### DIFF
--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -34,3 +34,11 @@ Before marking a ticket closed, confirm the closeout artifact includes:
 
 Use JSON mode when evidence needs to be consumed by scripts/tools (artifact generators, dashboards, checks):
 - `python3 cli/bb.py repo-health --json`
+
+## Timestamped artifact task (preferred for closeout evidence)
+
+Use the dedicated mise task to generate standardized evidence files:
+- `mise run repo-health:artifact`
+
+Expected output pattern:
+- `_bmad_output/evidence/repo-health-<utc-timestamp>.json`


### PR DESCRIPTION
## Summary
Document the standardized artifact workflow for BMAD closeout evidence.

## Changes
- Update `_bmad_output/README.md` with a new section for:
  - `mise run repo-health:artifact`
- Document expected output path pattern:
  - `_bmad_output/evidence/repo-health-<utc-timestamp>.json`

## Verification
- `mise run repo-health:artifact`

## Why
Closes #72 by aligning closeout docs with the new standardized artifact task.

Closes #72
