### PR TITLE
chore: ignore generated repo-health evidence artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ htmlcov/
 .pytest_cache/
 .tox/
 .hypothesis/
+
+# BMAD generated evidence artifacts
+_bmad_output/evidence/repo-health-*.json

--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -42,3 +42,5 @@ Use the dedicated mise task to generate standardized evidence files:
 
 Expected output pattern:
 - `_bmad_output/evidence/repo-health-<utc-timestamp>.json`
+
+Generated evidence files are runtime artifacts and should not be committed.


### PR DESCRIPTION
## Summary
Prevent generated repo-health artifacts from polluting git status and PRs.

## Changes
- Add ignore rule for generated files:
  - `_bmad_output/evidence/repo-health-*.json`
- Add BMAD note clarifying generated evidence artifacts should not be committed.

## Verification
- `mise run repo-health:artifact`
- `git status --short` (shows only intentional doc/ignore edits; generated artifact stays untracked+ignored)

## Why
Closes #74 by ensuring `repo-health:artifact` output remains local runtime evidence, not committed repo content.

Closes #74
