### PR TITLE
ops: add repo-health artifact cleanup task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run repo-health`  | `cli/bb.py repo-health` — read-only git/issue/PR/check snapshot |
 | `mise run repo-health:json` | `cli/bb.py repo-health --json` — structured snapshot for scripts/tools |
 | `mise run repo-health:artifact` | timestamped JSON evidence file under `_bmad_output/evidence/` |
+| `mise run repo-health:cleanup` | remove generated `repo-health-*.json` artifacts from `_bmad_output/evidence/` |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/mise.toml
+++ b/mise.toml
@@ -48,6 +48,12 @@ run = """
 bash -lc 'ts=$(date -u +%Y%m%dT%H%M%SZ); out="_bmad_output/evidence/repo-health-${ts}.json"; python3 cli/bb.py repo-health --json --out "$out"; echo "$out"'
 """
 
+[tasks."repo-health:cleanup"]
+description = "Remove generated repo-health JSON artifacts under _bmad_output/evidence"
+run = """
+bash -lc 'dir="_bmad_output/evidence"; if [ ! -d "$dir" ]; then echo "removed 0 repo-health artifacts"; exit 0; fi; count=$(find "$dir" -maxdepth 1 -type f -name "repo-health-*.json" | wc -l | tr -d " "); find "$dir" -maxdepth 1 -type f -name "repo-health-*.json" -delete; echo "removed ${count} repo-health artifacts"'
+"""
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"


### PR DESCRIPTION
## Summary
Add a cleanup task for generated repo-health evidence artifacts.

## Changes
- Add `mise run repo-health:cleanup` to `mise.toml`.
- Cleanup task removes generated files matching:
  - `_bmad_output/evidence/repo-health-*.json`
- Add task entry to `AGENTS.md` mise task table.

## Verification
- `mise run repo-health:artifact`
- `mise run repo-health:cleanup`
- `find _bmad_output/evidence -maxdepth 1 -type f -name 'repo-health-*.json' | wc -l` → `0`

## Why
Closes #76 by adding a local hygiene command to clear generated evidence artifacts.

Closes #76
