### PR TITLE
ops: add KEEP retention mode to repo-health cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run repo-health`  | `cli/bb.py repo-health` — read-only git/issue/PR/check snapshot |
 | `mise run repo-health:json` | `cli/bb.py repo-health --json` — structured snapshot for scripts/tools |
 | `mise run repo-health:artifact` | timestamped JSON evidence file under `_bmad_output/evidence/` |
-| `mise run repo-health:cleanup` | remove generated `repo-health-*.json` artifacts from `_bmad_output/evidence/` |
+| `mise run repo-health:cleanup` | remove generated artifacts; optional `KEEP=N` retains newest N snapshots |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -44,3 +44,6 @@ Expected output pattern:
 - `_bmad_output/evidence/repo-health-<utc-timestamp>.json`
 
 Generated evidence files are runtime artifacts and should not be committed.
+Use cleanup as needed:
+- `mise run repo-health:cleanup` (remove all generated snapshots)
+- `KEEP=5 mise run repo-health:cleanup` (keep newest 5)

--- a/mise.toml
+++ b/mise.toml
@@ -49,9 +49,9 @@ bash -lc 'ts=$(date -u +%Y%m%dT%H%M%SZ); out="_bmad_output/evidence/repo-health-
 """
 
 [tasks."repo-health:cleanup"]
-description = "Remove generated repo-health JSON artifacts under _bmad_output/evidence"
+description = "Remove generated repo-health artifacts (optional KEEP=N retains newest N)"
 run = """
-bash -lc 'dir="_bmad_output/evidence"; if [ ! -d "$dir" ]; then echo "removed 0 repo-health artifacts"; exit 0; fi; count=$(find "$dir" -maxdepth 1 -type f -name "repo-health-*.json" | wc -l | tr -d " "); find "$dir" -maxdepth 1 -type f -name "repo-health-*.json" -delete; echo "removed ${count} repo-health artifacts"'
+bash -lc 'dir="_bmad_output/evidence"; if [ ! -d "$dir" ]; then echo "removed 0 repo-health artifacts"; exit 0; fi; mapfile -t files < <(find "$dir" -maxdepth 1 -type f -name "repo-health-*.json" | sort); total=$(printf "%s\n" "${files[@]}" | sed "/^$/d" | wc -l | tr -d " "); keep="${KEEP:-}"; if [ -z "$keep" ]; then for f in "${files[@]}"; do rm -f "$f"; done; echo "removed ${total} repo-health artifacts"; exit 0; fi; if ! [[ "$keep" =~ ^[0-9]+$ ]]; then echo "KEEP must be a non-negative integer"; exit 2; fi; if [ "$keep" -ge "$total" ]; then echo "removed 0 repo-health artifacts (kept ${total})"; exit 0; fi; remove_count=$((total - keep)); for ((i=0; i<remove_count; i++)); do rm -f "${files[$i]}"; done; echo "removed ${remove_count} repo-health artifacts (kept ${keep})"'
 """
 
 [tasks.bootstrap]


### PR DESCRIPTION
## Summary
Add optional retention mode to repo-health artifact cleanup.

## Changes
- Extend `mise run repo-health:cleanup` to support `KEEP=N`.
- Default behavior unchanged: no `KEEP` removes all generated snapshots.
- Document usage in:
  - `AGENTS.md`
  - `_bmad_output/README.md`

## Verification
- `KEEP=1 mise run repo-health:cleanup` (keeps newest snapshot only)
- `mise run repo-health:cleanup` (removes all)

## Why
Closes #78 by enabling rolling snapshot retention while preserving simple default cleanup behavior.

Closes #78
