### PR TITLE
ops: add report mode to repo-health cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run repo-health`  | `cli/bb.py repo-health` — read-only git/issue/PR/check snapshot |
 | `mise run repo-health:json` | `cli/bb.py repo-health --json` — structured snapshot for scripts/tools |
 | `mise run repo-health:artifact` | timestamped JSON evidence file under `_bmad_output/evidence/` |
-| `mise run repo-health:cleanup` | remove generated artifacts; optional `KEEP=N` retains newest N snapshots |
+| `mise run repo-health:cleanup` | remove generated artifacts; optional `KEEP=N` retention and `REPORT=1` JSON output |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -47,3 +47,4 @@ Generated evidence files are runtime artifacts and should not be committed.
 Use cleanup as needed:
 - `mise run repo-health:cleanup` (remove all generated snapshots)
 - `KEEP=5 mise run repo-health:cleanup` (keep newest 5)
+- `KEEP=5 REPORT=1 mise run repo-health:cleanup` (JSON report with removed/kept counts and paths)

--- a/mise.toml
+++ b/mise.toml
@@ -49,10 +49,8 @@ bash -lc 'ts=$(date -u +%Y%m%dT%H%M%SZ); out="_bmad_output/evidence/repo-health-
 """
 
 [tasks."repo-health:cleanup"]
-description = "Remove generated repo-health artifacts (optional KEEP=N retains newest N)"
-run = """
-bash -lc 'dir="_bmad_output/evidence"; if [ ! -d "$dir" ]; then echo "removed 0 repo-health artifacts"; exit 0; fi; mapfile -t files < <(find "$dir" -maxdepth 1 -type f -name "repo-health-*.json" | sort); total=$(printf "%s\n" "${files[@]}" | sed "/^$/d" | wc -l | tr -d " "); keep="${KEEP:-}"; if [ -z "$keep" ]; then for f in "${files[@]}"; do rm -f "$f"; done; echo "removed ${total} repo-health artifacts"; exit 0; fi; if ! [[ "$keep" =~ ^[0-9]+$ ]]; then echo "KEEP must be a non-negative integer"; exit 2; fi; if [ "$keep" -ge "$total" ]; then echo "removed 0 repo-health artifacts (kept ${total})"; exit 0; fi; remove_count=$((total - keep)); for ((i=0; i<remove_count; i++)); do rm -f "${files[$i]}"; done; echo "removed ${remove_count} repo-health artifacts (kept ${keep})"'
-"""
+description = "Remove generated artifacts (KEEP=N retains newest N, REPORT=1 emits JSON report)"
+run = "python3 ops/repo-health/cleanup.py"
 
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"

--- a/ops/repo-health/cleanup.py
+++ b/ops/repo-health/cleanup.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Cleanup generated repo-health evidence artifacts.
+
+Env vars:
+- KEEP: optional non-negative integer; keep newest N artifacts.
+- REPORT: if truthy (1/true/yes/on), emit JSON report.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def main() -> int:
+    evidence_dir = Path("_bmad_output/evidence")
+    files = sorted(evidence_dir.glob("repo-health-*.json")) if evidence_dir.exists() else []
+
+    keep_raw = os.getenv("KEEP")
+    keep: int | None = None
+    if keep_raw not in (None, ""):
+        try:
+            keep = int(keep_raw)
+        except ValueError:
+            print("KEEP must be a non-negative integer", file=sys.stderr)
+            return 2
+        if keep < 0:
+            print("KEEP must be a non-negative integer", file=sys.stderr)
+            return 2
+
+    if keep is None:
+        kept = []
+        removed = files
+    elif keep == 0:
+        kept = []
+        removed = files
+    elif keep >= len(files):
+        kept = files
+        removed = []
+    else:
+        split = len(files) - keep
+        removed = files[:split]
+        kept = files[split:]
+
+    for path in removed:
+        path.unlink(missing_ok=True)
+
+    report = {
+        "pattern": "_bmad_output/evidence/repo-health-*.json",
+        "total_before": len(files),
+        "removed_count": len(removed),
+        "kept_count": len(kept),
+        "removed_paths": [str(p) for p in removed],
+        "kept_paths": [str(p) for p in kept],
+        "keep_requested": keep,
+    }
+
+    if _truthy(os.getenv("REPORT")):
+        print(json.dumps(report, indent=2))
+    else:
+        if keep is None:
+            print(f"removed {len(removed)} repo-health artifacts")
+        else:
+            print(f"removed {len(removed)} repo-health artifacts (kept {len(kept)})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Add report mode to the repo-health cleanup workflow.

## Changes
- Replace inline cleanup shell with `ops/repo-health/cleanup.py`.
- Add optional `REPORT=1` JSON output including:
  - removed/kept counts
  - removed/kept file paths
- Preserve existing cleanup behavior:
  - default removes all generated snapshots
  - `KEEP=N` retains newest N snapshots
- Update task/docs in `mise.toml`, `AGENTS.md`, and `_bmad_output/README.md`.

## Verification
- `REPORT=1 KEEP=1 mise run repo-health:cleanup`
- `REPORT=1 mise run repo-health:cleanup`

## Why
Closes #80 by adding machine-friendly cleanup evidence reporting while keeping default output simple.

Closes #80
