### PR TITLE
ops: add dry-run mode to repo-health cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run repo-health`  | `cli/bb.py repo-health` — read-only git/issue/PR/check snapshot |
 | `mise run repo-health:json` | `cli/bb.py repo-health --json` — structured snapshot for scripts/tools |
 | `mise run repo-health:artifact` | timestamped JSON evidence file under `_bmad_output/evidence/` |
-| `mise run repo-health:cleanup` | remove generated artifacts; optional `KEEP=N` retention and `REPORT=1` JSON output |
+| `mise run repo-health:cleanup` | remove generated artifacts; optional `KEEP=N`, `REPORT=1`, and `DRY_RUN=1` preview |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -48,3 +48,4 @@ Use cleanup as needed:
 - `mise run repo-health:cleanup` (remove all generated snapshots)
 - `KEEP=5 mise run repo-health:cleanup` (keep newest 5)
 - `KEEP=5 REPORT=1 mise run repo-health:cleanup` (JSON report with removed/kept counts and paths)
+- `DRY_RUN=1 KEEP=5 REPORT=1 mise run repo-health:cleanup` (preview only; no file deletions)

--- a/mise.toml
+++ b/mise.toml
@@ -49,7 +49,7 @@ bash -lc 'ts=$(date -u +%Y%m%dT%H%M%SZ); out="_bmad_output/evidence/repo-health-
 """
 
 [tasks."repo-health:cleanup"]
-description = "Remove generated artifacts (KEEP=N retains newest N, REPORT=1 emits JSON report)"
+description = "Remove generated artifacts (KEEP=N retention, REPORT=1 JSON, DRY_RUN=1 preview)"
 run = "python3 ops/repo-health/cleanup.py"
 
 [tasks.bootstrap]

--- a/ops/repo-health/cleanup.py
+++ b/ops/repo-health/cleanup.py
@@ -4,6 +4,7 @@
 Env vars:
 - KEEP: optional non-negative integer; keep newest N artifacts.
 - REPORT: if truthy (1/true/yes/on), emit JSON report.
+- DRY_RUN: if truthy, compute and report actions but do not delete files.
 """
 
 from __future__ import annotations
@@ -50,8 +51,10 @@ def main() -> int:
         removed = files[:split]
         kept = files[split:]
 
-    for path in removed:
-        path.unlink(missing_ok=True)
+    dry_run = _truthy(os.getenv("DRY_RUN"))
+    if not dry_run:
+        for path in removed:
+            path.unlink(missing_ok=True)
 
     report = {
         "pattern": "_bmad_output/evidence/repo-health-*.json",
@@ -61,15 +64,17 @@ def main() -> int:
         "removed_paths": [str(p) for p in removed],
         "kept_paths": [str(p) for p in kept],
         "keep_requested": keep,
+        "dry_run": dry_run,
     }
 
     if _truthy(os.getenv("REPORT")):
         print(json.dumps(report, indent=2))
     else:
+        verb = "would remove" if dry_run else "removed"
         if keep is None:
-            print(f"removed {len(removed)} repo-health artifacts")
+            print(f"{verb} {len(removed)} repo-health artifacts")
         else:
-            print(f"removed {len(removed)} repo-health artifacts (kept {len(kept)})")
+            print(f"{verb} {len(removed)} repo-health artifacts (kept {len(kept)})")
 
     return 0
 


### PR DESCRIPTION
## Summary
Add dry-run mode to the repo-health cleanup workflow.

## Changes
- Extend `ops/repo-health/cleanup.py` with `DRY_RUN=1` support.
- Dry-run mode computes and reports removed/kept files but does not delete artifacts.
- Keep existing behavior unchanged when `DRY_RUN` is not set.
- Include `dry_run` field in JSON report output.
- Update docs/usage in:
  - `mise.toml`
  - `AGENTS.md`
  - `_bmad_output/README.md`

## Verification
- `DRY_RUN=1 KEEP=1 REPORT=1 mise run repo-health:cleanup`
- Verify artifact count unchanged in dry-run mode (`before=2`, `after_dry=2`)
- `mise run repo-health:cleanup` then clears generated artifacts (`final=0`)

## Why
Closes #84 by enabling non-destructive preview for cleanup decisions.

Closes #84
