### PR TITLE
chore: ignore local openclaw hook workspace drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ htmlcov/
 
 # BMAD generated evidence artifacts
 _bmad_output/evidence/repo-health-*.json
+
+# Local OpenClaw hook workspace artifacts (operator-local; not project source)
+/services/agent-hooks/openclaw/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ alongside each service, using Holyfields-generated publishers.
   - `gh run view <run-id> --log-failed` excerpt (error signature)
   - follow-up ticket URL when the fix is out of current PR scope
 - For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json`.
+- Local OpenClaw hook scratch path (`services/agent-hooks/openclaw/`) is intentionally treated as operator-local and excluded from repo tracking.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.
 
 ## Conventions


### PR DESCRIPTION
## Summary
Resolve recurring untracked workspace drift from local OpenClaw hook artifacts.

## Changes
- Add scoped ignore rule:
  - `/services/agent-hooks/openclaw/`
- Document ownership decision in operator guide:
  - treat `services/agent-hooks/openclaw/` as operator-local scratch, not tracked project source.

## Verification
- `git status --short --branch` (untracked hook drift no longer appears)
- `python3 cli/bb.py repo-health --json`

## Why
Closes #86 by restoring clean-tree repo-health behavior while documenting the intended tracking policy.

Closes #86
