### PR TITLE
feat: add explicit worktree_dirty repo-health signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ alongside each service, using Holyfields-generated publishers.
   - failing check run URL
   - `gh run view <run-id> --log-failed` excerpt (error signature)
   - follow-up ticket URL when the fix is out of current PR scope
-- For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json`.
+- For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
 - Local OpenClaw hook scratch path (`services/agent-hooks/openclaw/`) is intentionally treated as operator-local and excluded from repo tracking.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.
 

--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -34,6 +34,7 @@ Before marking a ticket closed, confirm the closeout artifact includes:
 
 Use JSON mode when evidence needs to be consumed by scripts/tools (artifact generators, dashboards, checks):
 - `python3 cli/bb.py repo-health --json`
+- JSON includes `worktree_dirty` for explicit clean/dirty worktree checks.
 
 ## Timestamped artifact task (preferred for closeout evidence)
 

--- a/cli/bb.py
+++ b/cli/bb.py
@@ -203,6 +203,7 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
 
     snapshot: dict[str, object] = {
         "git_status": None,
+        "worktree_dirty": None,
         "issues_open": [],
         "prs_open": [],
         "latest_pr_checks": None,
@@ -229,8 +230,10 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
         print(rendered_error)
         return 2
 
-    git_line = git_out.splitlines()[0] if git_out else "<no status output>"
+    git_lines = git_out.splitlines()
+    git_line = git_lines[0] if git_lines else "<no status output>"
     snapshot["git_status"] = git_line
+    snapshot["worktree_dirty"] = len(git_lines) > 1
 
     rc_issue, issue_out, issue_err = _run(
         root,
@@ -312,6 +315,7 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
     else:
         lines_out: list[str] = []
         lines_out.append(f"git_status: {snapshot['git_status']}")
+        lines_out.append(f"worktree_dirty: {str(snapshot['worktree_dirty']).lower()}")
 
         issues_out = snapshot["issues_open"]
         assert isinstance(issues_out, list)


### PR DESCRIPTION
## Summary
Add an explicit clean/dirty worktree signal to `bb repo-health` output.

## Changes
- Add `worktree_dirty` to `repo-health` JSON output.
- Add `worktree_dirty: true|false` line in text output near `git_status`.
- Preserve existing output fields/behavior.
- Update operator docs references in:
  - `AGENTS.md`
  - `_bmad_output/README.md`

## Verification
- `python3 cli/bb.py repo-health --json`
- `python3 cli/bb.py repo-health --limit 3`

## Why
Closes #90 by removing brittle parsing needs for worktree cleanliness checks.

Closes #90
