### PR TITLE
feat: add strict clean-worktree mode to repo-health

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ alongside each service, using Holyfields-generated publishers.
   - `gh run view <run-id> --log-failed` excerpt (error signature)
   - follow-up ticket URL when the fix is out of current PR scope
 - For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
+- For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
 - Local OpenClaw hook scratch path (`services/agent-hooks/openclaw/`) is intentionally treated as operator-local and excluded from repo tracking.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.
 

--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -35,6 +35,7 @@ Before marking a ticket closed, confirm the closeout artifact includes:
 Use JSON mode when evidence needs to be consumed by scripts/tools (artifact generators, dashboards, checks):
 - `python3 cli/bb.py repo-health --json`
 - JSON includes `worktree_dirty` for explicit clean/dirty worktree checks.
+- Add `--require-clean-worktree` when the command should fail on dirty trees.
 
 ## Timestamped artifact task (preferred for closeout evidence)
 

--- a/cli/bb.py
+++ b/cli/bb.py
@@ -235,6 +235,13 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
     snapshot["git_status"] = git_line
     snapshot["worktree_dirty"] = len(git_lines) > 1
 
+    if args.require_clean_worktree and snapshot["worktree_dirty"] is True:
+        cast_errors = snapshot["errors"]
+        assert isinstance(cast_errors, list)
+        cast_errors.append(
+            "worktree_dirty: ERROR (working tree is dirty but --require-clean-worktree was set)"
+        )
+
     rc_issue, issue_out, issue_err = _run(
         root,
         "gh",
@@ -425,6 +432,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--out",
         dest="out_path",
         help="optional output file path for snapshot content",
+    )
+    p_repo_health.add_argument(
+        "--require-clean-worktree",
+        action="store_true",
+        dest="require_clean_worktree",
+        help="exit non-zero if the local git working tree is dirty",
     )
     p_repo_health.set_defaults(func=cmd_repo_health)
 


### PR DESCRIPTION
## Summary
Add strict clean-worktree mode to `bb repo-health`.

## Changes
- Add `--require-clean-worktree` flag to `bb repo-health`.
- When enabled and the worktree is dirty, append explicit error context and exit non-zero.
- Preserve default behavior when strict mode is not requested.
- Works in both JSON and text output modes.
- Update operator docs references in `AGENTS.md` and `_bmad_output/README.md`.

## Verification
- `python3 cli/bb.py repo-health --json`
- `python3 cli/bb.py repo-health --require-clean-worktree` (returns non-zero on dirty worktree)

## Why
Closes #92 by making clean-worktree enforcement first-class for BMAD quality gates.

Closes #92
