### PR TITLE
test: add strict worktree coverage to cleanup smoketest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:dapr-subscribe` | Dapr publish → subscribe              |
 | `mise run smoketest:heartbeat`      | Heartbeat producer/consumer end-to-end |
 | `mise run smoketest:claude-events`  | Claude `agent.*` event round-trip      |
-| `mise run smoketest:repo-health-cleanup` | local cleanup helper checks (default/KEEP/REPORT/error paths) |
+| `mise run smoketest:repo-health-cleanup` | local cleanup + strict worktree checks (default/KEEP/REPORT/DRY_RUN/error) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline

--- a/mise.toml
+++ b/mise.toml
@@ -81,7 +81,7 @@ description = "Claude agent.* event round-trip"
 run = "bash ops/smoketest/smoketest-claude-events.sh"
 
 [tasks."smoketest:repo-health-cleanup"]
-description = "Local smoke test for repo-health cleanup helper (KEEP/REPORT/error paths)"
+description = "Local smoke test for cleanup helper + strict worktree mode"
 run = "bash ops/smoketest/smoketest-repo-health-cleanup.sh"
 
 [tasks.logs]

--- a/ops/smoketest/smoketest-repo-health-cleanup.sh
+++ b/ops/smoketest/smoketest-repo-health-cleanup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Smoke test for ops/repo-health/cleanup.py
-# Covers default cleanup, KEEP retention, REPORT+DRY_RUN JSON, and invalid KEEP handling.
+# Smoke test for ops/repo-health/cleanup.py + strict repo-health worktree checks.
+# Covers default cleanup, KEEP retention, REPORT+DRY_RUN JSON,
+# invalid KEEP handling, and --require-clean-worktree pass/fail paths.
 
 set -euo pipefail
 
@@ -12,8 +13,10 @@ mkdir -p "${EVIDENCE_DIR}"
 
 BACKUP_DIR="$(mktemp -d)"
 restore_original=0
+DIRTY_TMP_FILE="${BLOODBANK_ROOT}/.tmp-repo-health-strict-smoke"
 
 cleanup_restore() {
+  rm -f "${DIRTY_TMP_FILE}" || true
   if [[ "${restore_original}" -eq 1 ]]; then
     find "${EVIDENCE_DIR}" -maxdepth 1 -type f -name 'repo-health-*.json' -delete || true
     if compgen -G "${BACKUP_DIR}/repo-health-*.json" > /dev/null; then
@@ -84,6 +87,33 @@ KEEP=abc python3 ops/repo-health/cleanup.py >/dev/null 2>&1
 rc=$?
 set -e
 [[ "$rc" -ne 0 ]] || { echo "invalid KEEP did not fail" >&2; exit 1; }
+
+# 6) strict clean-worktree mode should pass on clean tree
+strict_clean_json="$(python3 cli/bb.py repo-health --json --require-clean-worktree)"
+python3 - <<'PY' "${strict_clean_json}"
+import json
+import sys
+payload = json.loads(sys.argv[1])
+assert payload["worktree_dirty"] is False, payload
+assert payload["errors"] == [], payload
+PY
+
+# 7) strict clean-worktree mode should fail on dirty tree
+printf 'smoke-dirty\n' > "${DIRTY_TMP_FILE}"
+set +e
+strict_dirty_json="$(python3 cli/bb.py repo-health --json --require-clean-worktree 2>/dev/null)"
+strict_dirty_rc=$?
+set -e
+[[ "${strict_dirty_rc}" -ne 0 ]] || { echo "strict mode did not fail on dirty worktree" >&2; exit 1; }
+python3 - <<'PY' "${strict_dirty_json}"
+import json
+import sys
+payload = json.loads(sys.argv[1])
+assert payload["worktree_dirty"] is True, payload
+errors = payload.get("errors", [])
+assert any("require-clean-worktree" in e for e in errors), payload
+PY
+rm -f "${DIRTY_TMP_FILE}"
 
 # cleanup after test artifacts
 python3 ops/repo-health/cleanup.py >/dev/null


### PR DESCRIPTION
## Summary
Add smoketest coverage for repo-health strict clean-worktree mode.

## Changes
- Extend `ops/smoketest/smoketest-repo-health-cleanup.sh` with strict mode checks:
  - clean worktree + `--require-clean-worktree` exits 0,
  - dirty worktree + `--require-clean-worktree` exits non-zero,
  - strict failure payload includes explicit error context.
- Keep existing cleanup helper checks intact (default/KEEP/REPORT/DRY_RUN/invalid KEEP).
- Refresh task descriptions in:
  - `mise.toml`
  - `AGENTS.md`

## Verification
- `mise run smoketest:repo-health-cleanup`

## Why
Closes #94 by adding repeatable pass/fail coverage for strict clean-worktree gating.

Closes #94
