### PR TITLE
chore: add strict repo-health mise task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run doctor`       | `cli/bb.py doctor` — manifest-driven scaffold check |
 | `mise run repo-health`  | `cli/bb.py repo-health` — read-only git/issue/PR/check snapshot |
 | `mise run repo-health:json` | `cli/bb.py repo-health --json` — structured snapshot for scripts/tools |
+| `mise run repo-health:strict` | `cli/bb.py repo-health --require-clean-worktree` — fail gate on dirty trees |
 | `mise run repo-health:artifact` | timestamped JSON evidence file under `_bmad_output/evidence/` |
 | `mise run repo-health:cleanup` | remove generated artifacts; optional `KEEP=N`, `REPORT=1`, and `DRY_RUN=1` preview |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |

--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -36,6 +36,7 @@ Use JSON mode when evidence needs to be consumed by scripts/tools (artifact gene
 - `python3 cli/bb.py repo-health --json`
 - JSON includes `worktree_dirty` for explicit clean/dirty worktree checks.
 - Add `--require-clean-worktree` when the command should fail on dirty trees.
+- Shortcut task: `mise run repo-health:strict`.
 
 ## Timestamped artifact task (preferred for closeout evidence)
 

--- a/mise.toml
+++ b/mise.toml
@@ -42,6 +42,10 @@ run = "python3 cli/bb.py repo-health"
 description = "Read-only structured JSON snapshot for BMAD/scripted evidence"
 run = "python3 cli/bb.py repo-health --json"
 
+[tasks."repo-health:strict"]
+description = "Read-only strict gate: fail when worktree is not clean"
+run = "python3 cli/bb.py repo-health --require-clean-worktree"
+
 [tasks."repo-health:artifact"]
 description = "Write timestamped JSON BMAD evidence artifact under _bmad_output/evidence"
 run = """


### PR DESCRIPTION
## Summary
Add a first-class mise task for strict repo-health clean-worktree gates.

## Changes
- Add `repo-health:strict` task in `mise.toml`:
  - `python3 cli/bb.py repo-health --require-clean-worktree`
- Document the new task in:
  - `AGENTS.md` task table
  - `_bmad_output/README.md` structured snapshot guidance

## Verification
- `mise run repo-health:strict` (passes on clean worktree)

## Why
Closes #96 by making strict clean-worktree gating explicit and scriptable in standard operator workflows.

Closes #96
