### PR TITLE
chore: add BMAD closeout scaffold helper task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run repo-health:strict` | `cli/bb.py repo-health --require-clean-worktree` — fail gate on dirty trees |
 | `mise run repo-health:artifact` | timestamped JSON evidence file under `_bmad_output/evidence/` |
 | `mise run repo-health:cleanup` | remove generated artifacts; optional `KEEP=N`, `REPORT=1`, and `DRY_RUN=1` preview |
+| `ISSUE_ID=<id> mise run bmad:closeout-scaffold` | scaffold `_bmad_output/issue-<id>-execution.md` from template |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/_bmad_output/README.md
+++ b/_bmad_output/README.md
@@ -7,12 +7,18 @@ Ticket-scoped execution artifacts live here (notes, checklists, evidence snippet
 For every completed ticket, add one closeout file:
 - Path: `_bmad_output/issue-<id>-execution.md`
 - Starter template: `_bmad_output/templates/ticket-closeout.md`
+- Scaffold helper: `ISSUE_ID=<id> mise run bmad:closeout-scaffold`
 
 Required fields:
 - Ticket id + title
 - Scope completed (what changed / what did not)
 - Verification evidence (commands/checks and outcomes)
 - Links to issue + PR (and follow-ups if any)
+
+Scaffold helper options:
+- `ISSUE_TITLE='...'` to prefill the title
+- `OWNER='...'` to prefill owner
+- `OVERWRITE=1` to replace an existing closeout file
 
 ## Closeout artifact index
 

--- a/mise.toml
+++ b/mise.toml
@@ -56,6 +56,10 @@ bash -lc 'ts=$(date -u +%Y%m%dT%H%M%SZ); out="_bmad_output/evidence/repo-health-
 description = "Remove generated artifacts (KEEP=N retention, REPORT=1 JSON, DRY_RUN=1 preview)"
 run = "python3 ops/repo-health/cleanup.py"
 
+[tasks."bmad:closeout-scaffold"]
+description = "Scaffold _bmad_output/issue-<id>-execution.md from template (requires ISSUE_ID=...)"
+run = "python3 ops/bmad/scaffold_closeout.py"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"

--- a/ops/bmad/scaffold_closeout.py
+++ b/ops/bmad/scaffold_closeout.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Scaffold BMAD ticket closeout artifacts from template.
+
+Env vars:
+- ISSUE_ID: required positive integer ticket id.
+- ISSUE_TITLE: optional title to prefill.
+- OWNER: optional owner/agent to prefill.
+- OVERWRITE: truthy to allow replacing an existing closeout file.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def _truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _require_issue_id(raw: str | None) -> str:
+    if raw is None or not raw.strip():
+        raise ValueError("ISSUE_ID is required (example: ISSUE_ID=98)")
+    candidate = raw.strip()
+    if not re.fullmatch(r"[1-9]\d*", candidate):
+        raise ValueError("ISSUE_ID must be a positive integer")
+    return candidate
+
+
+def main() -> int:
+    try:
+        issue_id = _require_issue_id(os.getenv("ISSUE_ID"))
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    issue_title = os.getenv("ISSUE_TITLE", "<title>").strip() or "<title>"
+    owner = os.getenv("OWNER", "<name/agent>").strip() or "<name/agent>"
+
+    template_path = Path("_bmad_output/templates/ticket-closeout.md")
+    if not template_path.exists():
+        print(f"template missing: {template_path}", file=sys.stderr)
+        return 2
+
+    out_path = Path(f"_bmad_output/issue-{issue_id}-execution.md")
+    if out_path.exists() and not _truthy(os.getenv("OVERWRITE")):
+        print(
+            f"closeout already exists: {out_path} (set OVERWRITE=1 to replace)",
+            file=sys.stderr,
+        )
+        return 3
+
+    content = template_path.read_text(encoding="utf-8")
+    content = content.replace("<id>", issue_id)
+    content = content.replace("<title>", issue_title)
+    content = content.replace("<name/agent>", owner)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(content if content.endswith("\n") else content + "\n", encoding="utf-8")
+
+    print(str(out_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Add a helper task to scaffold BMAD ticket closeout artifacts from template.

## Changes
- Add `ops/bmad/scaffold_closeout.py`:
  - requires `ISSUE_ID` (positive integer),
  - creates `_bmad_output/issue-<id>-execution.md` from `_bmad_output/templates/ticket-closeout.md`,
  - refuses overwrite unless `OVERWRITE=1`,
  - supports optional `ISSUE_TITLE` and `OWNER` prefills.
- Add mise task:
  - `ISSUE_ID=<id> mise run bmad:closeout-scaffold`
- Document usage in:
  - `AGENTS.md`
  - `_bmad_output/README.md`

## Verification
- `mise run bmad:closeout-scaffold` → fails with clear error when `ISSUE_ID` missing.
- `ISSUE_ID=99999 ISSUE_TITLE='tmp title' OWNER='hermes' mise run bmad:closeout-scaffold` → creates file at expected path.

## Why
Closes #98 by standardizing and validating BMAD closeout artifact scaffolding.

Closes #98
