### PR TITLE
test: add smoketest for BMAD closeout scaffold helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:heartbeat`      | Heartbeat producer/consumer end-to-end |
 | `mise run smoketest:claude-events`  | Claude `agent.*` event round-trip      |
 | `mise run smoketest:repo-health-cleanup` | local cleanup + strict worktree checks (default/KEEP/REPORT/DRY_RUN/error) |
+| `mise run smoketest:bmad-closeout-scaffold` | local validation for closeout scaffold helper (required id/create/no-overwrite) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline

--- a/mise.toml
+++ b/mise.toml
@@ -92,6 +92,10 @@ run = "bash ops/smoketest/smoketest-claude-events.sh"
 description = "Local smoke test for cleanup helper + strict worktree mode"
 run = "bash ops/smoketest/smoketest-repo-health-cleanup.sh"
 
+[tasks."smoketest:bmad-closeout-scaffold"]
+description = "Local smoke test for BMAD closeout scaffold helper"
+run = "bash ops/smoketest/smoketest-bmad-closeout-scaffold.sh"
+
 [tasks.logs]
 description = "Tail every Bloodbank container"
 run = "docker compose --project-name $COMPOSE_PROJECT -f $COMPOSE_FILE logs -f"

--- a/ops/smoketest/smoketest-bmad-closeout-scaffold.sh
+++ b/ops/smoketest/smoketest-bmad-closeout-scaffold.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Smoke test for ops/bmad/scaffold_closeout.py
+# Covers required ISSUE_ID validation, successful scaffold creation,
+# and no-overwrite protection when target file already exists.
+
+set -euo pipefail
+
+BLOODBANK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${BLOODBANK_ROOT}"
+
+TMP_ISSUE_ID="99998"
+TMP_CLOSEOUT_PATH="_bmad_output/issue-${TMP_ISSUE_ID}-execution.md"
+
+cleanup() {
+  rm -f "${TMP_CLOSEOUT_PATH}" || true
+}
+trap cleanup EXIT
+
+rm -f "${TMP_CLOSEOUT_PATH}"
+
+# 1) missing ISSUE_ID should fail non-zero with clear error
+set +e
+missing_err="$(python3 ops/bmad/scaffold_closeout.py 2>&1 >/dev/null)"
+missing_rc=$?
+set -e
+[[ "${missing_rc}" -ne 0 ]] || { echo "missing ISSUE_ID did not fail" >&2; exit 1; }
+[[ "${missing_err}" == *"ISSUE_ID is required"* ]] || { echo "missing ISSUE_ID error message mismatch" >&2; exit 1; }
+
+# 2) valid ISSUE_ID should create expected closeout file
+create_out="$(ISSUE_ID="${TMP_ISSUE_ID}" ISSUE_TITLE="smoke title" OWNER="smoke-owner" python3 ops/bmad/scaffold_closeout.py)"
+[[ "${create_out}" == "${TMP_CLOSEOUT_PATH}" ]] || { echo "unexpected scaffold output path" >&2; exit 1; }
+[[ -f "${TMP_CLOSEOUT_PATH}" ]] || { echo "closeout file not created" >&2; exit 1; }
+
+grep -q "Issue: #${TMP_ISSUE_ID}" "${TMP_CLOSEOUT_PATH}" || { echo "issue id not rendered" >&2; exit 1; }
+grep -q "Title: smoke title" "${TMP_CLOSEOUT_PATH}" || { echo "title not rendered" >&2; exit 1; }
+grep -q "Owner: smoke-owner" "${TMP_CLOSEOUT_PATH}" || { echo "owner not rendered" >&2; exit 1; }
+
+# 3) second run without OVERWRITE should fail when file exists
+set +e
+exists_err="$(ISSUE_ID="${TMP_ISSUE_ID}" python3 ops/bmad/scaffold_closeout.py 2>&1 >/dev/null)"
+exists_rc=$?
+set -e
+[[ "${exists_rc}" -ne 0 ]] || { echo "existing file check did not fail" >&2; exit 1; }
+[[ "${exists_err}" == *"closeout already exists"* ]] || { echo "existing file error message mismatch" >&2; exit 1; }
+
+echo "smoketest-bmad-closeout-scaffold: PASS"


### PR DESCRIPTION
## Summary
Add repeatable smoke-test coverage for the BMAD closeout scaffold helper.

## Changes
- Add `ops/smoketest/smoketest-bmad-closeout-scaffold.sh` to validate:
  - missing `ISSUE_ID` fails non-zero with clear error,
  - valid scaffold creation writes expected `_bmad_output/issue-<id>-execution.md`,
  - second run without `OVERWRITE=1` fails when the file already exists.
- Add mise task:
  - `mise run smoketest:bmad-closeout-scaffold`
- Document task in `AGENTS.md` task table.

## Verification
- `mise run smoketest:bmad-closeout-scaffold` → PASS

## Why
Closes #100 by providing a reliable local validation path for closeout scaffold behavior and safety checks.

Closes #100
