### PR TITLE
chore: add consolidated ops smoketest task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:claude-events`  | Claude `agent.*` event round-trip      |
 | `mise run smoketest:repo-health-cleanup` | local cleanup + strict worktree checks (default/KEEP/REPORT/DRY_RUN/error) |
 | `mise run smoketest:bmad-closeout-scaffold` | local validation for closeout scaffold helper (required id/create/no-overwrite) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline

--- a/mise.toml
+++ b/mise.toml
@@ -96,6 +96,10 @@ run = "bash ops/smoketest/smoketest-repo-health-cleanup.sh"
 description = "Local smoke test for BMAD closeout scaffold helper"
 run = "bash ops/smoketest/smoketest-bmad-closeout-scaffold.sh"
 
+[tasks."smoketest:ops"]
+description = "Run consolidated local operator reliability smoke checks (fail-fast)"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold"
+
 [tasks.logs]
 description = "Tail every Bloodbank container"
 run = "docker compose --project-name $COMPOSE_PROJECT -f $COMPOSE_FILE logs -f"


### PR DESCRIPTION
## Summary
Add a consolidated local ops smoketest task for operator reliability checks.

## Changes
- Add `mise` task:
  - `smoketest:ops` → runs:
    - `smoketest:repo-health-cleanup`
    - `smoketest:bmad-closeout-scaffold`
- Task is fail-fast (`&&`) and returns non-zero on first failing step.
- Document new task in `AGENTS.md` task table.

## Verification
- `mise run smoketest:ops` → PASS
  - `smoketest-repo-health-cleanup: PASS`
  - `smoketest-bmad-closeout-scaffold: PASS`

## Why
Closes #102 by providing a single local command for core operator reliability checks used in BMAD closeout loops.

Closes #102
