### PR TITLE
docs: add clean-worktree automation path for dirty local main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ alongside each service, using Holyfields-generated publishers.
   - follow-up ticket URL when the fix is out of current PR scope
 - For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
+- If primary checkout is dirty/behind, use the dedicated clean-worktree automation path in `ops/bmad/clean-worktree-automation.md` (do not stash/discard unknown local changes).
 - Local OpenClaw hook scratch path (`services/agent-hooks/openclaw/`) is intentionally treated as operator-local and excluded from repo tracking.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.
 

--- a/ops/bmad/clean-worktree-automation.md
+++ b/ops/bmad/clean-worktree-automation.md
@@ -1,0 +1,43 @@
+# Clean-worktree automation path (Hermes/BMAD)
+
+Use this when your primary checkout is dirty and/or behind origin, and you need a safe ticket-first automation loop without touching local WIP.
+
+## Guardrails
+
+- Never stash, discard, or rewrite unknown local changes in the primary checkout.
+- Run automation work in a dedicated clean worktree created from `origin/main`.
+- Verify the automation worktree is clean and synced before creating ticket branches.
+- Keep primary checkout untouched; remove the temporary worktree when done.
+
+## Command recipe (copy/paste)
+
+```bash
+# from primary checkout (may be dirty)
+git fetch origin main
+
+# create isolated clean worktree rooted at origin/main
+git worktree add -b fix/issue-<id>-<slug> /tmp/bloodbank-issue-<id> origin/main
+
+# work from isolated tree
+cd /tmp/bloodbank-issue-<id>
+git status -sb  # expect clean branch off origin/main
+
+# implement + verify
+# ... edits/tests ...
+
+git add <files>
+git commit -m "<type>: <summary>"
+git push -u origin fix/issue-<id>-<slug>
+
+gh pr create --base main --head fix/issue-<id>-<slug> --title "<title>" --body "Closes #<id>"
+
+# optional cleanup after merge
+cd -
+git worktree remove /tmp/bloodbank-issue-<id>
+```
+
+## Notes
+
+- If `/tmp/bloodbank-issue-<id>` already exists, remove it first or choose a different path.
+- If your automation branch needs updates from `main`, pull/rebase in the isolated worktree only.
+- Keep ticket evidence in workspace memory logs as usual.


### PR DESCRIPTION
## Summary
Document a safe clean-worktree automation path for Hermes/BMAD loops when local main is dirty.

## Changes
- Add `ops/bmad/clean-worktree-automation.md` with:
  - explicit no-data-loss guardrails,
  - dedicated clean worktree workflow from `origin/main`,
  - copy/paste operator command recipe,
  - cleanup guidance.
- Add AGENTS baseline note linking to the new recipe.

## Verification
- Confirmed doc exists and AGENTS references it.
- Workflow used in practice for this ticket from isolated worktree `/tmp/bloodbank-hermes-104`.

## Why
Closes #104 by standardizing a safe automation path that preserves unknown local WIP in the primary checkout.

Closes #104
