### PR TITLE
chore: add clean worktree bootstrap helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run repo-health:artifact` | timestamped JSON evidence file under `_bmad_output/evidence/` |
 | `mise run repo-health:cleanup` | remove generated artifacts; optional `KEEP=N`, `REPORT=1`, and `DRY_RUN=1` preview |
 | `ISSUE_ID=<id> mise run bmad:closeout-scaffold` | scaffold `_bmad_output/issue-<id>-execution.md` from template |
+| `ISSUE_ID=<id> SLUG=<slug> mise run bmad:worktree-bootstrap` | bootstrap isolated clean worktree from `origin/main` for ticket loops |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/mise.toml
+++ b/mise.toml
@@ -60,6 +60,10 @@ run = "python3 ops/repo-health/cleanup.py"
 description = "Scaffold _bmad_output/issue-<id>-execution.md from template (requires ISSUE_ID=...)"
 run = "python3 ops/bmad/scaffold_closeout.py"
 
+[tasks."bmad:worktree-bootstrap"]
+description = "Bootstrap isolated clean automation worktree (requires ISSUE_ID + SLUG; REUSE=1 to reuse)"
+run = "python3 ops/bmad/bootstrap_clean_worktree.py"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"

--- a/ops/bmad/bootstrap_clean_worktree.py
+++ b/ops/bmad/bootstrap_clean_worktree.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Bootstrap an isolated clean worktree for ticket-first automation loops.
+
+Env vars:
+- ISSUE_ID: required positive integer.
+- SLUG: required branch slug (letters/numbers/dash/underscore accepted; normalized to kebab-case).
+- WORKTREE_BASE: optional base dir for temp worktrees (default: /tmp).
+- WORKTREE_PREFIX: optional path prefix (default: bloodbank-issue).
+- REUSE: truthy to reuse existing path/branch worktree when available.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=True, text=True, capture_output=True)
+
+
+def _require_issue_id(raw: str | None) -> str:
+    if raw is None or not raw.strip():
+        raise ValueError("ISSUE_ID is required (example: ISSUE_ID=106)")
+    candidate = raw.strip()
+    if not re.fullmatch(r"[1-9]\d*", candidate):
+        raise ValueError("ISSUE_ID must be a positive integer")
+    return candidate
+
+
+def _require_slug(raw: str | None) -> str:
+    if raw is None or not raw.strip():
+        raise ValueError("SLUG is required (example: SLUG=worktree-bootstrap-helper)")
+    normalized = re.sub(r"[^a-z0-9_-]+", "-", raw.strip().lower()).strip("-_")
+    normalized = normalized.replace("_", "-")
+    normalized = re.sub(r"-+", "-", normalized)
+    if not normalized:
+        raise ValueError("SLUG normalized to empty value; provide a meaningful slug")
+    return normalized
+
+
+def _worktree_paths() -> set[str]:
+    out = _run("git", "worktree", "list", "--porcelain").stdout
+    paths: set[str] = set()
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            paths.add(line.split(" ", 1)[1].strip())
+    return paths
+
+
+def main() -> int:
+    try:
+        issue_id = _require_issue_id(os.getenv("ISSUE_ID"))
+        slug = _require_slug(os.getenv("SLUG"))
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    reuse = _truthy(os.getenv("REUSE"))
+    worktree_base = Path(os.getenv("WORKTREE_BASE", "/tmp"))
+    prefix = os.getenv("WORKTREE_PREFIX", "bloodbank-issue").strip() or "bloodbank-issue"
+
+    branch = f"fix/issue-{issue_id}-{slug}"
+    worktree_path = (worktree_base / f"{prefix}-{issue_id}").resolve()
+
+    # Always sync main ref before creating/reusing worktree.
+    _run("git", "fetch", "origin", "main")
+
+    known_paths = _worktree_paths()
+    path_exists = worktree_path.exists()
+    path_known = str(worktree_path) in known_paths
+
+    created = False
+    reused = False
+
+    if path_exists or path_known:
+        if not reuse:
+            print(
+                f"worktree path already exists: {worktree_path} (set REUSE=1 to reuse)",
+                file=sys.stderr,
+            )
+            return 3
+        if not path_known:
+            print(
+                f"path exists but is not a registered git worktree: {worktree_path}",
+                file=sys.stderr,
+            )
+            return 3
+        reused = True
+    else:
+        branch_exists = (
+            subprocess.run(
+                ["git", "show-ref", "--verify", f"refs/heads/{branch}"],
+                text=True,
+                capture_output=True,
+            ).returncode
+            == 0
+        )
+        if branch_exists:
+            _run("git", "worktree", "add", str(worktree_path), branch)
+        else:
+            _run("git", "worktree", "add", "-b", branch, str(worktree_path), "origin/main")
+        created = True
+
+    action = "created" if created else "reused"
+    print(f"WORKTREE_{action.upper()}: {worktree_path}")
+    print(f"BRANCH: {branch}")
+    print("NEXT:")
+    print(f"  cd {worktree_path}")
+    print("  git status -sb")
+    print("  # implement + verify, then commit/push/pr")
+    print(f"CLEANUP:")
+    print(f"  git worktree remove {worktree_path}")
+    if not reused:
+        print(f"  git branch -d {branch}  # after merge")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/bmad/clean-worktree-automation.md
+++ b/ops/bmad/clean-worktree-automation.md
@@ -11,6 +11,16 @@ Use this when your primary checkout is dirty and/or behind origin, and you need 
 
 ## Command recipe (copy/paste)
 
+Preferred helper path:
+
+```bash
+# from primary checkout (may be dirty)
+ISSUE_ID=<id> SLUG=<slug> mise run bmad:worktree-bootstrap
+# optional: REUSE=1 ISSUE_ID=<id> SLUG=<slug> mise run bmad:worktree-bootstrap
+```
+
+Manual equivalent:
+
 ```bash
 # from primary checkout (may be dirty)
 git fetch origin main


### PR DESCRIPTION
## Summary
Add a helper to bootstrap isolated clean worktrees for ticket-first automation loops.

## Changes
- Add `ops/bmad/bootstrap_clean_worktree.py`:
  - requires `ISSUE_ID` and `SLUG`,
  - fetches `origin/main`,
  - creates branch `fix/issue-<id>-<slug>` from `origin/main`,
  - creates/reuses temp worktree path (`REUSE=1` for reuse),
  - prints worktree path, branch, next-step commands, and explicit cleanup commands.
- Add mise task:
  - `ISSUE_ID=<id> SLUG=<slug> mise run bmad:worktree-bootstrap`
- Update docs:
  - `AGENTS.md` task table entry
  - `ops/bmad/clean-worktree-automation.md` helper-first guidance

## Verification
- `python3 ops/bmad/bootstrap_clean_worktree.py` → fails with clear error when `ISSUE_ID` missing.
- `ISSUE_ID=106 SLUG=bootstrap-test python3 ops/bmad/bootstrap_clean_worktree.py` → creates worktree/branch and prints next/cleanup commands.
- Verified created worktree branch status, then removed temp worktree and deleted test branch.

## Why
Closes #106 by providing a repeatable, no-touch-primary-checkout helper for automation loops.

Closes #106
