### PR TITLE
feat: add read-only primary checkout drift snapshot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run repo-health`  | `cli/bb.py repo-health` — read-only git/issue/PR/check snapshot |
 | `mise run repo-health:json` | `cli/bb.py repo-health --json` — structured snapshot for scripts/tools |
 | `mise run repo-health:strict` | `cli/bb.py repo-health --require-clean-worktree` — fail gate on dirty trees |
+| `mise run repo-health:drift` | read-only drift snapshot (ahead/behind + modified/untracked + top-level buckets) |
 | `mise run repo-health:artifact` | timestamped JSON evidence file under `_bmad_output/evidence/` |
 | `mise run repo-health:cleanup` | remove generated artifacts; optional `KEEP=N`, `REPORT=1`, and `DRY_RUN=1` preview |
 | `ISSUE_ID=<id> mise run bmad:closeout-scaffold` | scaffold `_bmad_output/issue-<id>-execution.md` from template |
@@ -75,6 +76,7 @@ alongside each service, using Holyfields-generated publishers.
   - follow-up ticket URL when the fix is out of current PR scope
 - For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
+- For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.
 - If primary checkout is dirty/behind, use the dedicated clean-worktree automation path in `ops/bmad/clean-worktree-automation.md` (do not stash/discard unknown local changes).
 - Local OpenClaw hook scratch path (`services/agent-hooks/openclaw/`) is intentionally treated as operator-local and excluded from repo tracking.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.

--- a/mise.toml
+++ b/mise.toml
@@ -46,6 +46,10 @@ run = "python3 cli/bb.py repo-health --json"
 description = "Read-only strict gate: fail when worktree is not clean"
 run = "python3 cli/bb.py repo-health --require-clean-worktree"
 
+[tasks."repo-health:drift"]
+description = "Read-only drift snapshot (branch divergence + modified/untracked + top-level buckets)"
+run = "python3 ops/repo-health/drift_snapshot.py --repo ."
+
 [tasks."repo-health:artifact"]
 description = "Write timestamped JSON BMAD evidence artifact under _bmad_output/evidence"
 run = """

--- a/ops/repo-health/drift_snapshot.py
+++ b/ops/repo-health/drift_snapshot.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Read-only git drift snapshot for operator loop evidence.
+
+Reports branch divergence + working-tree drift summary without mutating state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    cp = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return cp.stdout.strip("\n")
+
+
+def _parse_branch_status(line: str) -> tuple[str, str | None, int, int]:
+    # Examples:
+    # ## main
+    # ## main...origin/main
+    # ## main...origin/main [ahead 1, behind 3]
+    payload = line.removeprefix("## ")
+    branch = payload
+    upstream = None
+    ahead = 0
+    behind = 0
+
+    if "..." in payload:
+        branch, rest = payload.split("...", 1)
+        branch = branch.strip()
+        if " [" in rest and rest.endswith("]"):
+            upstream, meta = rest.split(" [", 1)
+            upstream = upstream.strip() or None
+            meta = meta[:-1]
+            parts = [p.strip() for p in meta.split(",")]
+            for part in parts:
+                if part.startswith("ahead "):
+                    ahead = int(part.split(" ", 1)[1])
+                elif part.startswith("behind "):
+                    behind = int(part.split(" ", 1)[1])
+        else:
+            upstream = rest.strip() or None
+    else:
+        branch = payload.strip()
+
+    return branch, upstream, ahead, behind
+
+
+def _path_from_status_line(line: str) -> str | None:
+    if not line:
+        return None
+    if line.startswith("## "):
+        return None
+
+    # porcelain short format: XY <path>
+    body = line[3:] if len(line) >= 4 else ""
+    if not body:
+        return None
+
+    # Renames are rendered as "old -> new".
+    if " -> " in body:
+        body = body.split(" -> ", 1)[1]
+
+    return body.strip() or None
+
+
+def snapshot(repo: Path) -> dict[str, object]:
+    status = _run_git(repo, "status", "--short", "--branch")
+    lines = status.splitlines()
+
+    if not lines:
+        raise RuntimeError("empty git status output")
+
+    branch, upstream, ahead, behind = _parse_branch_status(lines[0])
+
+    tracked_modified = 0
+    untracked = 0
+    buckets: Counter[str] = Counter()
+
+    for line in lines[1:]:
+        if not line:
+            continue
+        code = line[:2]
+        if code == "??":
+            untracked += 1
+        else:
+            tracked_modified += 1
+
+        path = _path_from_status_line(line)
+        if path:
+            top = path.split("/", 1)[0]
+            buckets[top] += 1
+
+    return {
+        "repo": str(repo.resolve()),
+        "branch": branch,
+        "upstream": upstream,
+        "ahead": ahead,
+        "behind": behind,
+        "tracked_modified_count": tracked_modified,
+        "untracked_count": untracked,
+        "top_level_path_buckets": dict(sorted(buckets.items())),
+    }
+
+
+def render_text(data: dict[str, object]) -> str:
+    lines: list[str] = []
+    lines.append(f"repo: {data['repo']}")
+    lines.append(f"branch: {data['branch']}")
+    lines.append(f"upstream: {data['upstream'] or 'none'}")
+    lines.append(f"ahead: {data['ahead']}")
+    lines.append(f"behind: {data['behind']}")
+    lines.append(f"tracked_modified_count: {data['tracked_modified_count']}")
+    lines.append(f"untracked_count: {data['untracked_count']}")
+    lines.append("top_level_path_buckets:")
+
+    buckets: dict[str, int] = data["top_level_path_buckets"]  # type: ignore[assignment]
+    if not buckets:
+        lines.append("- none")
+    else:
+        for key, count in buckets.items():
+            lines.append(f"- {key}: {count}")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Read-only git drift snapshot")
+    parser.add_argument("--repo", default=".", help="Path to git repository (default: .)")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    args = parser.parse_args()
+
+    repo = Path(args.repo)
+    data = snapshot(repo)
+
+    if args.json:
+        print(json.dumps(data, indent=2))
+    else:
+        print(render_text(data))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Add a read-only drift snapshot command for primary checkout hygiene/evidence in operator loops.

## Changes
- Add `ops/repo-health/drift_snapshot.py`:
  - read-only status snapshot (no stash/reset/pull),
  - reports branch/upstream + ahead/behind,
  - reports `tracked_modified_count` and `untracked_count`,
  - reports top-level changed path buckets,
  - supports text and `--json` output,
  - supports `--repo <path>` so loops can snapshot primary checkout from isolated automation worktrees.
- Add mise task:
  - `mise run repo-health:drift`
- Update operator docs:
  - task table entry in `AGENTS.md`,
  - BMAD baseline note for drift evidence logging in `AGENTS.md`.

## Verification
- `python3 ops/repo-health/drift_snapshot.py --repo . --json` (development worktree snapshot)
- `python3 ops/repo-health/drift_snapshot.py --repo /home/delorenj/code/33GOD/bloodbank --json` (primary checkout snapshot)
- `python3 ops/repo-health/drift_snapshot.py --repo /home/delorenj/code/33GOD/bloodbank` (text output)

## Why
Closes #108 by standardizing non-mutating drift evidence capture for Hermes/BMAD loops.

Closes #108
