### PR TITLE
chore: add safe PR merge helper for linked worktree cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run repo-health:cleanup` | remove generated artifacts; optional `KEEP=N`, `REPORT=1`, and `DRY_RUN=1` preview |
 | `ISSUE_ID=<id> mise run bmad:closeout-scaffold` | scaffold `_bmad_output/issue-<id>-execution.md` from template |
 | `ISSUE_ID=<id> SLUG=<slug> mise run bmad:worktree-bootstrap` | bootstrap isolated clean worktree from `origin/main` for ticket loops |
+| `mise run bmad:pr-merge-safe -- <pr>` | safe squash merge + merged-state verification + cleanup follow-ups |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/mise.toml
+++ b/mise.toml
@@ -68,6 +68,10 @@ run = "python3 ops/bmad/scaffold_closeout.py"
 description = "Bootstrap isolated clean automation worktree (requires ISSUE_ID + SLUG; REUSE=1 to reuse)"
 run = "python3 ops/bmad/bootstrap_clean_worktree.py"
 
+[tasks."bmad:pr-merge-safe"]
+description = "Safely merge PR with merged-state verification; linked-worktree cleanup handled as follow-up"
+run = "python3 ops/bmad/merge_pr_safe.py"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"

--- a/ops/bmad/clean-worktree-automation.md
+++ b/ops/bmad/clean-worktree-automation.md
@@ -46,6 +46,12 @@ cd -
 git worktree remove /tmp/bloodbank-issue-<id>
 ```
 
+Optional safe merge helper (handles linked-worktree delete edge case):
+
+```bash
+mise run bmad:pr-merge-safe -- <pr-number-or-url>
+```
+
 ## Notes
 
 - If `/tmp/bloodbank-issue-<id>` already exists, remove it first or choose a different path.

--- a/ops/bmad/merge_pr_safe.py
+++ b/ops/bmad/merge_pr_safe.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Safely merge a PR for operator loops, tolerating linked-worktree delete edge cases.
+
+- Attempts squash merge + remote branch delete.
+- Verifies merged state independently via `gh pr view`.
+- Treats local branch/worktree cleanup as best-effort follow-up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class CmdResult:
+    code: int
+    out: str
+    err: str
+
+
+def run(*args: str) -> CmdResult:
+    cp = subprocess.run(args, text=True, capture_output=True)
+    return CmdResult(code=cp.returncode, out=cp.stdout.strip(), err=cp.stderr.strip())
+
+
+def gh_pr_view(pr: str) -> dict[str, object]:
+    cp = subprocess.run(
+        ["gh", "pr", "view", pr, "--json", "number,state,mergedAt,url,headRefName"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(cp.stdout)
+
+
+def worktree_paths_for_branch(branch: str) -> list[str]:
+    cp = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    paths: list[str] = []
+    current_path: str | None = None
+    current_branch: str | None = None
+
+    for line in cp.stdout.splitlines():
+        if line.startswith("worktree "):
+            current_path = line.split(" ", 1)[1].strip()
+            current_branch = None
+        elif line.startswith("branch "):
+            current_branch = line.split(" ", 1)[1].strip().removeprefix("refs/heads/")
+            if current_path and current_branch == branch:
+                paths.append(current_path)
+
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Safe PR merge helper for operator loops")
+    parser.add_argument("pr", help="PR number or URL")
+    args = parser.parse_args()
+
+    merge = run("gh", "pr", "merge", args.pr, "--squash", "--delete-branch")
+
+    try:
+        view = gh_pr_view(args.pr)
+    except subprocess.CalledProcessError as exc:
+        print(f"pr_view_error: {exc.stderr.strip() or exc}", file=sys.stderr)
+        if merge.out:
+            print(merge.out)
+        if merge.err:
+            print(merge.err, file=sys.stderr)
+        return merge.code or 1
+
+    state = str(view.get("state") or "")
+    merged_at = view.get("mergedAt")
+    pr_url = str(view.get("url") or "")
+    head_branch = str(view.get("headRefName") or "")
+
+    merged = state == "MERGED" and bool(merged_at)
+
+    report: dict[str, object] = {
+        "pr": view.get("number"),
+        "url": pr_url,
+        "state": state,
+        "mergedAt": merged_at,
+        "merge_command_exit": merge.code,
+        "merge_command_stderr": merge.err,
+        "head_branch": head_branch,
+        "cleanup": {
+            "local_branch_deleted": None,
+            "linked_worktrees": [],
+            "followup_commands": [],
+        },
+    }
+
+    if not merged:
+        print(json.dumps(report, indent=2))
+        return merge.code or 1
+
+    cleanup = report["cleanup"]
+    if head_branch:
+        del_res = run("git", "branch", "-d", head_branch)
+        if del_res.code == 0:
+            cleanup["local_branch_deleted"] = True
+        else:
+            cleanup["local_branch_deleted"] = False
+            paths = worktree_paths_for_branch(head_branch)
+            cleanup["linked_worktrees"] = paths
+            followups: list[str] = []
+            for path in paths:
+                followups.append(f"git worktree remove {path}")
+            followups.append(f"git branch -d {head_branch}")
+            cleanup["followup_commands"] = followups
+
+    # Success even if merge command failed, as long as PR is confirmed merged.
+    # This covers linked-worktree local deletion failures from gh merge.
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Add a safe PR merge helper for operator loops that verifies merged state and separates local cleanup follow-up.

## Changes
- Add `ops/bmad/merge_pr_safe.py`:
  - runs `gh pr merge --squash --delete-branch`,
  - verifies merged state via `gh pr view`,
  - returns success when PR is confirmed merged (even if local branch deletion hits linked-worktree edge cases),
  - emits cleanup report including linked worktree paths and explicit follow-up commands.
- Add mise task:
  - `mise run bmad:pr-merge-safe -- <pr>`
- Update docs:
  - `AGENTS.md` task table
  - `ops/bmad/clean-worktree-automation.md` helper note

## Verification
- `python3 ops/bmad/merge_pr_safe.py 109` (already merged PR verification path)
- Simulated linked-worktree cleanup edge case for head branch `fix/issue-108-primary-drift-snapshot` and verified helper reports:
  - linked worktree path(s),
  - follow-up cleanup commands.
- Removed temporary test worktree and branch after verification.

## Why
Closes #110 by preventing false-error loop behavior when merge succeeds but local branch deletion is blocked by an active linked worktree.

Closes #110
