### PR TITLE
chore: add unified BMAD closeout helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ alongside each service, using Holyfields-generated publishers.
 | `ISSUE_ID=<id> mise run bmad:closeout-scaffold` | scaffold `_bmad_output/issue-<id>-execution.md` from template |
 | `ISSUE_ID=<id> SLUG=<slug> mise run bmad:worktree-bootstrap` | bootstrap isolated clean worktree from `origin/main` for ticket loops |
 | `mise run bmad:pr-merge-safe -- <pr>` | safe squash merge + merged-state verification + cleanup follow-ups |
+| `mise run bmad:closeout-loop -- <pr> --primary-repo <path>` | unified closeout summary (merge+cleanup+drift evidence, JSON) |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/mise.toml
+++ b/mise.toml
@@ -72,6 +72,10 @@ run = "python3 ops/bmad/bootstrap_clean_worktree.py"
 description = "Safely merge PR with merged-state verification; linked-worktree cleanup handled as follow-up"
 run = "python3 ops/bmad/merge_pr_safe.py"
 
+[tasks."bmad:closeout-loop"]
+description = "Unified closeout helper: safe merge + cleanup follow-ups + primary drift snapshot"
+run = "python3 ops/bmad/closeout_loop.py"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"

--- a/ops/bmad/clean-worktree-automation.md
+++ b/ops/bmad/clean-worktree-automation.md
@@ -52,6 +52,12 @@ Optional safe merge helper (handles linked-worktree delete edge case):
 mise run bmad:pr-merge-safe -- <pr-number-or-url>
 ```
 
+Unified closeout helper (merge verification + cleanup follow-ups + primary drift evidence):
+
+```bash
+mise run bmad:closeout-loop -- <pr-number-or-url> --primary-repo /path/to/primary/checkout
+```
+
 ## Notes
 
 - If `/tmp/bloodbank-issue-<id>` already exists, remove it first or choose a different path.

--- a/ops/bmad/closeout_loop.py
+++ b/ops/bmad/closeout_loop.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unified BMAD loop closeout helper.
+
+Combines:
+1) safe PR merge + merged-state verification,
+2) cleanup follow-up visibility (linked worktree/local branch),
+3) read-only primary-checkout drift snapshot evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_json(command: list[str]) -> tuple[int, dict[str, object] | None, str, str]:
+    cp = subprocess.run(command, text=True, capture_output=True)
+    out = cp.stdout.strip()
+    err = cp.stderr.strip()
+    payload: dict[str, object] | None = None
+    if out:
+        try:
+            payload = json.loads(out)
+        except json.JSONDecodeError:
+            payload = None
+    return cp.returncode, payload, out, err
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Unified BMAD closeout helper")
+    parser.add_argument("pr", help="PR number or URL")
+    parser.add_argument(
+        "--primary-repo",
+        required=True,
+        help="Path to primary checkout for read-only drift evidence snapshot",
+    )
+    args = parser.parse_args()
+
+    merge_cmd = ["python3", "ops/bmad/merge_pr_safe.py", args.pr]
+    merge_rc, merge_payload, merge_out, merge_err = _run_json(merge_cmd)
+
+    drift_cmd = [
+        "python3",
+        "ops/repo-health/drift_snapshot.py",
+        "--repo",
+        str(Path(args.primary_repo)),
+        "--json",
+    ]
+    drift_rc, drift_payload, drift_out, drift_err = _run_json(drift_cmd)
+
+    merged = bool(merge_payload and merge_payload.get("state") == "MERGED" and merge_payload.get("mergedAt"))
+    drift_ok = drift_rc == 0 and drift_payload is not None
+
+    warnings: list[str] = []
+    cleanup_followups: list[str] = []
+    if merge_payload:
+        cleanup = merge_payload.get("cleanup")
+        if isinstance(cleanup, dict):
+            local_deleted = cleanup.get("local_branch_deleted")
+            if local_deleted is False:
+                warnings.append("local branch cleanup requires follow-up")
+            cmds = cleanup.get("followup_commands")
+            if isinstance(cmds, list):
+                cleanup_followups = [str(c) for c in cmds]
+
+    if merge_rc != 0 and merged:
+        warnings.append("merge command returned non-zero but PR is confirmed merged")
+
+    if not drift_ok:
+        warnings.append("primary drift snapshot failed")
+
+    report: dict[str, object] = {
+        "pr": args.pr,
+        "primary_repo": str(Path(args.primary_repo).resolve()),
+        "merged": merged,
+        "drift_snapshot_ok": drift_ok,
+        "merge": merge_payload,
+        "drift": drift_payload,
+        "cleanup_followup_commands": cleanup_followups,
+        "warnings": warnings,
+        "overall_status": "ok" if (merged and drift_ok) else "error",
+        "diagnostics": {
+            "merge_rc": merge_rc,
+            "drift_rc": drift_rc,
+            "merge_stderr": merge_err,
+            "drift_stderr": drift_err,
+            "merge_stdout_raw": merge_out if merge_payload is None else None,
+            "drift_stdout_raw": drift_out if drift_payload is None else None,
+        },
+    }
+
+    print(json.dumps(report, indent=2))
+    return 0 if (merged and drift_ok) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Add a unified BMAD loop closeout helper that combines merge verification, cleanup follow-up visibility, and primary drift evidence in one JSON output.

## Changes
- Add `ops/bmad/closeout_loop.py`:
  - runs safe merge helper (`merge_pr_safe.py`),
  - verifies merged state,
  - runs read-only primary drift snapshot (`drift_snapshot.py --json`),
  - emits machine-readable JSON summary,
  - returns non-zero only when closeout is not actually complete.
- Add mise task:
  - `mise run bmad:closeout-loop -- <pr> --primary-repo <path>`
- Update docs:
  - `AGENTS.md` task table
  - `ops/bmad/clean-worktree-automation.md`

## Verification
- `python3 ops/bmad/closeout_loop.py 111 --primary-repo /home/delorenj/code/33GOD/bloodbank`
  - `merged: true`
  - `drift_snapshot_ok: true`
  - `overall_status: ok`

## Why
Closes #112 by providing one auditable closeout flow for Hermes/BMAD loops.

Closes #112
