### PR TITLE
test: add smoketest for unified BMAD closeout helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bloodbank-naming` | Stdlib contract verifier (no Docker) for §14 sequence × {claude, copilot} + negative probes |
 | `mise run smoketest:repo-health-cleanup` | local cleanup + strict worktree checks (default/KEEP/REPORT/DRY_RUN/error) |
 | `mise run smoketest:bmad-closeout-scaffold` | local validation for closeout scaffold helper (required id/create/no-overwrite) |
+| `mise run smoketest:bmad-closeout-loop` | local validation for unified closeout helper JSON/evidence fields |
 | `mise run smoketest:ops` | consolidated local operator reliability smoke checks (fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 

--- a/mise.toml
+++ b/mise.toml
@@ -116,6 +116,10 @@ run = "bash ops/smoketest/smoketest-repo-health-cleanup.sh"
 description = "Local smoke test for BMAD closeout scaffold helper"
 run = "bash ops/smoketest/smoketest-bmad-closeout-scaffold.sh"
 
+[tasks."smoketest:bmad-closeout-loop"]
+description = "Local smoke test for unified BMAD closeout helper JSON/evidence path"
+run = "bash ops/smoketest/smoketest-bmad-closeout-loop.sh"
+
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
 run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold"

--- a/ops/smoketest/smoketest-bmad-closeout-loop.sh
+++ b/ops/smoketest/smoketest-bmad-closeout-loop.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Smoke test for ops/bmad/closeout_loop.py
+# Covers machine-readable JSON output and key closeout fields using
+# a non-destructive already-merged PR reference.
+
+set -euo pipefail
+
+BLOODBANK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${BLOODBANK_ROOT}"
+
+PRIMARY_REPO="${PRIMARY_REPO:-${BLOODBANK_ROOT}}"
+MERGED_PR="${MERGED_PR:-113}"
+
+closeout_json="$(python3 ops/bmad/closeout_loop.py "${MERGED_PR}" --primary-repo "${PRIMARY_REPO}")"
+
+python3 - <<'PY' "${closeout_json}"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+for key in [
+    "overall_status",
+    "merged",
+    "drift_snapshot_ok",
+    "cleanup_followup_commands",
+    "merge",
+    "drift",
+]:
+    assert key in payload, payload
+
+assert payload["overall_status"] == "ok", payload
+assert payload["merged"] is True, payload
+assert payload["drift_snapshot_ok"] is True, payload
+assert isinstance(payload["cleanup_followup_commands"], list), payload
+assert isinstance(payload["merge"], dict), payload
+assert isinstance(payload["drift"], dict), payload
+PY
+
+echo "smoketest-bmad-closeout-loop: PASS"


### PR DESCRIPTION
## Summary
Add smoke-test coverage for the unified BMAD closeout helper.

## Changes
- Add `ops/smoketest/smoketest-bmad-closeout-loop.sh` to validate:
  - helper emits machine-readable JSON,
  - key fields are present (`overall_status`, `merged`, `drift_snapshot_ok`, `cleanup_followup_commands`, `merge`, `drift`),
  - non-destructive already-merged PR path returns expected success semantics.
- Add mise task:
  - `mise run smoketest:bmad-closeout-loop`
- Update docs:
  - `AGENTS.md` task table entry.

## Verification
- `mise run smoketest:bmad-closeout-loop` → PASS

## Why
Closes #114 by adding repeatable local validation for the unified closeout helper path.

Closes #114
