### PR TITLE
chore: include closeout-loop smoke in consolidated ops smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:repo-health-cleanup` | local cleanup + strict worktree checks (default/KEEP/REPORT/DRY_RUN/error) |
 | `mise run smoketest:bmad-closeout-scaffold` | local validation for closeout scaffold helper (required id/create/no-overwrite) |
 | `mise run smoketest:bmad-closeout-loop` | local validation for unified closeout helper JSON/evidence fields |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (fail-fast) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline

--- a/mise.toml
+++ b/mise.toml
@@ -122,7 +122,7 @@ run = "bash ops/smoketest/smoketest-bmad-closeout-loop.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"


### PR DESCRIPTION
## Summary
Include unified closeout smoke in the consolidated ops smoke task.

## Changes
- Update `smoketest:ops` to run all three fail-fast checks:
  - `smoketest:repo-health-cleanup`
  - `smoketest:bmad-closeout-scaffold`
  - `smoketest:bmad-closeout-loop`
- Update `AGENTS.md` task table description accordingly.

## Verification
- `mise run smoketest:ops` → PASS
  - `smoketest-repo-health-cleanup: PASS`
  - `smoketest-bmad-closeout-scaffold: PASS`
  - `smoketest-bmad-closeout-loop: PASS`

## Why
Closes #116 by ensuring one-command operator smoke coverage includes the unified closeout helper path.

Closes #116
