### PR TITLE
test: add smoketest for safe PR merge helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:repo-health-cleanup` | local cleanup + strict worktree checks (default/KEEP/REPORT/DRY_RUN/error) |
 | `mise run smoketest:bmad-closeout-scaffold` | local validation for closeout scaffold helper (required id/create/no-overwrite) |
 | `mise run smoketest:bmad-closeout-loop` | local validation for unified closeout helper JSON/evidence fields |
+| `mise run smoketest:bmad-merge-pr-safe` | local validation for safe merge helper JSON/cleanup follow-up fields |
 | `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 

--- a/mise.toml
+++ b/mise.toml
@@ -120,6 +120,10 @@ run = "bash ops/smoketest/smoketest-bmad-closeout-scaffold.sh"
 description = "Local smoke test for unified BMAD closeout helper JSON/evidence path"
 run = "bash ops/smoketest/smoketest-bmad-closeout-loop.sh"
 
+[tasks."smoketest:bmad-merge-pr-safe"]
+description = "Local smoke test for safe PR merge helper JSON/cleanup fields"
+run = "bash ops/smoketest/smoketest-bmad-merge-pr-safe.sh"
+
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
 run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop"

--- a/ops/smoketest/smoketest-bmad-merge-pr-safe.sh
+++ b/ops/smoketest/smoketest-bmad-merge-pr-safe.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Smoke test for ops/bmad/merge_pr_safe.py
+# Covers machine-readable JSON output and key merge/cleanup fields
+# using an already merged PR reference (non-destructive path).
+
+set -euo pipefail
+
+BLOODBANK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${BLOODBANK_ROOT}"
+
+MERGED_PR="${MERGED_PR:-117}"
+
+merge_json="$(python3 ops/bmad/merge_pr_safe.py "${MERGED_PR}")"
+
+python3 - <<'PY' "${merge_json}"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+for key in ["state", "mergedAt", "merge_command_exit", "cleanup"]:
+    assert key in payload, payload
+
+assert payload["state"] == "MERGED", payload
+assert payload["mergedAt"], payload
+assert isinstance(payload["merge_command_exit"], int), payload
+
+cleanup = payload["cleanup"]
+assert isinstance(cleanup, dict), payload
+for key in ["local_branch_deleted", "followup_commands"]:
+    assert key in cleanup, payload
+assert isinstance(cleanup["followup_commands"], list), payload
+PY
+
+echo "smoketest-bmad-merge-pr-safe: PASS"


### PR DESCRIPTION
## Summary
Add smoke-test coverage for the safe PR merge helper.

## Changes
- Add `ops/smoketest/smoketest-bmad-merge-pr-safe.sh` to validate:
  - helper emits machine-readable JSON,
  - key fields exist (`state`, `mergedAt`, `merge_command_exit`, `cleanup.local_branch_deleted`, `cleanup.followup_commands`),
  - non-destructive already-merged PR reference path.
- Add mise task:
  - `mise run smoketest:bmad-merge-pr-safe`
- Update docs:
  - `AGENTS.md` task table entry.

## Verification
- `mise run smoketest:bmad-merge-pr-safe` → PASS

## Why
Closes #118 by adding repeatable local validation for the safe merge helper output contract.

Closes #118
