### PR TITLE
chore: include merge-safe smoke in consolidated ops smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-closeout-scaffold` | local validation for closeout scaffold helper (required id/create/no-overwrite) |
 | `mise run smoketest:bmad-closeout-loop` | local validation for unified closeout helper JSON/evidence fields |
 | `mise run smoketest:bmad-merge-pr-safe` | local validation for safe merge helper JSON/cleanup follow-up fields |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop, fail-fast) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline

--- a/mise.toml
+++ b/mise.toml
@@ -126,7 +126,7 @@ run = "bash ops/smoketest/smoketest-bmad-merge-pr-safe.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"


### PR DESCRIPTION
## Summary
Include safe-merge smoke in the consolidated ops smoke task.

## Changes
- Update `smoketest:ops` fail-fast chain to include:
  - `smoketest:repo-health-cleanup`
  - `smoketest:bmad-closeout-scaffold`
  - `smoketest:bmad-closeout-loop`
  - `smoketest:bmad-merge-pr-safe`
- Update `AGENTS.md` task-table description to reflect expanded coverage.

## Verification
- `mise run smoketest:ops` → PASS
  - `smoketest-repo-health-cleanup: PASS`
  - `smoketest-bmad-closeout-scaffold: PASS`
  - `smoketest-bmad-closeout-loop: PASS`
  - `smoketest-bmad-merge-pr-safe: PASS`

## Why
Closes #120 by making the one-command operator reliability gate cover all BMAD helper smoke paths.

Closes #120
