### PR TITLE
feat: default closeout-loop primary repo resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ alongside each service, using Holyfields-generated publishers.
 | `ISSUE_ID=<id> mise run bmad:closeout-scaffold` | scaffold `_bmad_output/issue-<id>-execution.md` from template |
 | `ISSUE_ID=<id> SLUG=<slug> mise run bmad:worktree-bootstrap` | bootstrap isolated clean worktree from `origin/main` for ticket loops |
 | `mise run bmad:pr-merge-safe -- <pr>` | safe squash merge + merged-state verification + cleanup follow-ups |
-| `mise run bmad:closeout-loop -- <pr> --primary-repo <path>` | unified closeout summary (merge+cleanup+drift evidence, JSON) |
+| `mise run bmad:closeout-loop -- <pr> [--primary-repo <path>]` | unified closeout summary (merge+cleanup+drift evidence, JSON; defaults `PRIMARY_REPO` env then cwd) |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/ops/bmad/clean-worktree-automation.md
+++ b/ops/bmad/clean-worktree-automation.md
@@ -55,7 +55,12 @@ mise run bmad:pr-merge-safe -- <pr-number-or-url>
 Unified closeout helper (merge verification + cleanup follow-ups + primary drift evidence):
 
 ```bash
+# optional explicit path:
 mise run bmad:closeout-loop -- <pr-number-or-url> --primary-repo /path/to/primary/checkout
+# or rely on defaults:
+#   1) PRIMARY_REPO env
+#   2) current working directory
+mise run bmad:closeout-loop -- <pr-number-or-url>
 ```
 
 ## Notes

--- a/ops/bmad/closeout_loop.py
+++ b/ops/bmad/closeout_loop.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -29,15 +30,59 @@ def _run_json(command: list[str]) -> tuple[int, dict[str, object] | None, str, s
     return cp.returncode, payload, out, err
 
 
+def _is_git_repo(path: Path) -> bool:
+    cp = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--is-inside-work-tree"],
+        text=True,
+        capture_output=True,
+    )
+    return cp.returncode == 0 and cp.stdout.strip() == "true"
+
+
+def _resolve_primary_repo(cli_value: str | None) -> tuple[Path, str]:
+    if cli_value:
+        return Path(cli_value), "cli"
+
+    env_value = os.getenv("PRIMARY_REPO")
+    if env_value:
+        return Path(env_value), "env:PRIMARY_REPO"
+
+    return Path.cwd(), "cwd"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Unified BMAD closeout helper")
     parser.add_argument("pr", help="PR number or URL")
     parser.add_argument(
         "--primary-repo",
-        required=True,
-        help="Path to primary checkout for read-only drift evidence snapshot",
+        help="Path to primary checkout for read-only drift evidence snapshot (optional: defaults PRIMARY_REPO env, then cwd)",
     )
     args = parser.parse_args()
+
+    primary_repo, primary_repo_source = _resolve_primary_repo(args.primary_repo)
+
+    if not _is_git_repo(primary_repo):
+        print(
+            json.dumps(
+                {
+                    "pr": args.pr,
+                    "primary_repo": str(primary_repo.resolve()),
+                    "primary_repo_source": primary_repo_source,
+                    "overall_status": "error",
+                    "warnings": ["resolved primary repo is not a git worktree"],
+                    "diagnostics": {
+                        "merge_rc": None,
+                        "drift_rc": None,
+                        "merge_stderr": "",
+                        "drift_stderr": "",
+                        "merge_stdout_raw": None,
+                        "drift_stdout_raw": None,
+                    },
+                },
+                indent=2,
+            )
+        )
+        return 1
 
     merge_cmd = ["python3", "ops/bmad/merge_pr_safe.py", args.pr]
     merge_rc, merge_payload, merge_out, merge_err = _run_json(merge_cmd)
@@ -46,7 +91,7 @@ def main() -> int:
         "python3",
         "ops/repo-health/drift_snapshot.py",
         "--repo",
-        str(Path(args.primary_repo)),
+        str(primary_repo),
         "--json",
     ]
     drift_rc, drift_payload, drift_out, drift_err = _run_json(drift_cmd)
@@ -74,7 +119,8 @@ def main() -> int:
 
     report: dict[str, object] = {
         "pr": args.pr,
-        "primary_repo": str(Path(args.primary_repo).resolve()),
+        "primary_repo": str(primary_repo.resolve()),
+        "primary_repo_source": primary_repo_source,
         "merged": merged,
         "drift_snapshot_ok": drift_ok,
         "merge": merge_payload,


### PR DESCRIPTION
## Summary
Improve `closeout_loop.py` ergonomics by adding default primary-repo resolution.

## Changes
- `ops/bmad/closeout_loop.py`
  - Make `--primary-repo` optional.
  - Resolve primary checkout in fallback order:
    1. explicit `--primary-repo`
    2. `PRIMARY_REPO` env
    3. current working directory
  - Add git-worktree validation for resolved path.
  - Add `primary_repo_source` field to JSON output.
- Docs updates:
  - `AGENTS.md` task table usage line
  - `ops/bmad/clean-worktree-automation.md` usage examples

## Verification
- `mise run smoketest:bmad-closeout-loop` → PASS
- `python3 ops/bmad/closeout_loop.py 121` (no `--primary-repo`) → PASS (`overall_status=ok`)

## Why
Closes #122 by reducing repetitive CLI friction in Hermes/BMAD loops while keeping explicit override behavior.

Closes #122
