### PR TITLE
test: harden merge-pr-safe smoke output contract

### DIFF
--- a/_bmad_output/issue-126-execution.md
+++ b/_bmad_output/issue-126-execution.md
@@ -1,0 +1,24 @@
+# Issue 126 — execution closeout
+
+## Ticket
+- Issue: #126
+- Title: Harden merge-pr-safe smoke output-contract coverage
+- Owner: hermes (pilot)
+
+## Scope completed
+- Scaffolded BMAD closeout artifact for ticket-first execution tracking.
+
+## Out of scope
+- Final closeout completion (pending PR merge + CI completion).
+
+## Verification evidence
+- `mise run smoketest:bmad-merge-pr-safe` → `PASS` (2026-05-15)
+- `mise run repo-health:artifact` → `_bmad_output/evidence/repo-health-20260515T080111Z.json`
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/126
+- PR: https://github.com/delorenj/bloodbank/pull/127
+- Follow-up tickets: none
+
+## Notes
+- PR checks are queued (`Static checks`, `claude-review`, `Smoke tests`) as of 2026-05-15 08:00 UTC.

--- a/ops/smoketest/smoketest-bmad-merge-pr-safe.sh
+++ b/ops/smoketest/smoketest-bmad-merge-pr-safe.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Smoke test for ops/bmad/merge_pr_safe.py
-# Covers machine-readable JSON output and key merge/cleanup fields
+# Covers machine-readable JSON output and merge/cleanup contract fields
 # using an already merged PR reference (non-destructive path).
 
 set -euo pipefail
@@ -17,17 +17,29 @@ import json
 import sys
 
 payload = json.loads(sys.argv[1])
-for key in ["state", "mergedAt", "merge_command_exit", "cleanup"]:
+for key in [
+    "state",
+    "mergedAt",
+    "merge_command_exit",
+    "merge_command_stderr",
+    "head_branch",
+    "cleanup",
+]:
     assert key in payload, payload
 
 assert payload["state"] == "MERGED", payload
 assert payload["mergedAt"], payload
 assert isinstance(payload["merge_command_exit"], int), payload
+assert isinstance(payload["merge_command_stderr"], str), payload
+
+if payload["head_branch"] is not None:
+    assert isinstance(payload["head_branch"], str), payload
 
 cleanup = payload["cleanup"]
 assert isinstance(cleanup, dict), payload
-for key in ["local_branch_deleted", "followup_commands"]:
+for key in ["local_branch_deleted", "linked_worktrees", "followup_commands"]:
     assert key in cleanup, payload
+assert isinstance(cleanup["linked_worktrees"], list), payload
 assert isinstance(cleanup["followup_commands"], list), payload
 PY
 


### PR DESCRIPTION
## Summary
Harden `merge_pr_safe.py` smoke coverage for additional output-contract fields.

## Changes
- Extended `ops/smoketest/smoketest-bmad-merge-pr-safe.sh` assertions to validate:
  - top-level `merge_command_stderr` exists and is a string
  - top-level `head_branch` exists and is a string when present
  - `cleanup.linked_worktrees` exists and is a list
  - existing checks remain for `state`, `mergedAt`, `merge_command_exit`, `cleanup.local_branch_deleted`, and `cleanup.followup_commands`
- Kept non-destructive path via already-merged PR reference.

## Verification
- `mise run smoketest:bmad-merge-pr-safe` → PASS
- `mise run smoketest:ops` → PASS

## Why
Closes #126 by strengthening local smoke guarantees for merge-safe machine-readable output relied on by automation.

Closes #126
