### PR TITLE
feat: add operator-safe PR check retrigger helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   # Cancel in-progress runs on the same branch when a new commit lands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ alongside each service, using Holyfields-generated publishers.
 | `ISSUE_ID=<id> SLUG=<slug> mise run bmad:worktree-bootstrap` | bootstrap isolated clean worktree from `origin/main` for ticket loops |
 | `mise run bmad:pr-merge-safe -- <pr>` | safe squash merge + merged-state verification + cleanup follow-ups |
 | `mise run bmad:closeout-loop -- <pr> [--primary-repo <path>]` | unified closeout summary (merge+cleanup+drift evidence, JSON; defaults `PRIMARY_REPO` env then cwd) |
+| `mise run bmad:retrigger-pr-checks -- <pr> [--workflow ci.yml] [--dry-run]` | dispatch CI workflow for PR head branch without no-op commit retriggers |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |
@@ -63,7 +64,8 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-closeout-scaffold` | local validation for closeout scaffold helper (required id/create/no-overwrite) |
 | `mise run smoketest:bmad-closeout-loop` | local validation for unified closeout helper JSON/evidence fields |
 | `mise run smoketest:bmad-merge-pr-safe` | local validation for safe merge helper JSON/cleanup follow-up fields |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe, fail-fast) |
+| `mise run smoketest:bmad-retrigger-pr-checks` | local validation for PR check retrigger helper JSON contract (dry-run path) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline

--- a/_bmad_output/issue-128-execution.md
+++ b/_bmad_output/issue-128-execution.md
@@ -1,0 +1,25 @@
+# Issue 128 — execution closeout
+
+## Ticket
+- Issue: #128
+- Title: Investigate queued-workflow rerun failure for PR smoke jobs
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added `ops/bmad/retrigger_pr_checks.py` helper to dispatch CI workflow for a PR head branch without no-op commits.
+- Added local dry-run contract smoke test and wired new mise tasks/documentation for operator recovery flow.
+
+## Out of scope
+- Root-cause proof for the queued/failure mismatch in GitHub Actions internals.
+
+## Verification evidence
+- `mise run smoketest:bmad-retrigger-pr-checks` → `PASS`
+- `python3 -m py_compile ops/bmad/retrigger_pr_checks.py` → success (no syntax errors)
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/128
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- `mise run smoketest:ops` currently fails on dirty working tree because `smoketest:repo-health-cleanup` asserts strict-clean mode; expected during in-progress branch edits.

--- a/mise.toml
+++ b/mise.toml
@@ -76,6 +76,10 @@ run = "python3 ops/bmad/merge_pr_safe.py"
 description = "Unified closeout helper: safe merge + cleanup follow-ups + primary drift snapshot"
 run = "python3 ops/bmad/closeout_loop.py"
 
+[tasks."bmad:retrigger-pr-checks"]
+description = "Dispatch CI workflow for a PR head branch (no empty commit retrigger)"
+run = "python3 ops/bmad/retrigger_pr_checks.py"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"
@@ -124,9 +128,13 @@ run = "bash ops/smoketest/smoketest-bmad-closeout-loop.sh"
 description = "Local smoke test for safe PR merge helper JSON/cleanup fields"
 run = "bash ops/smoketest/smoketest-bmad-merge-pr-safe.sh"
 
+[tasks."smoketest:bmad-retrigger-pr-checks"]
+description = "Local smoke test for PR check retrigger helper JSON contract (dry-run)"
+run = "bash ops/smoketest/smoketest-bmad-retrigger-pr-checks.sh"
+
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/pr-check-retrigger.md
+++ b/ops/bmad/pr-check-retrigger.md
@@ -1,0 +1,20 @@
+# PR check retrigger (no-op commit alternative)
+
+When a PR workflow run cannot be rerun from GitHub UI/CLI (for example queued jobs in a failed run), dispatch CI directly on the PR head branch:
+
+```bash
+mise run bmad:retrigger-pr-checks -- <pr-number>
+```
+
+Dry-run (contract + target verification only):
+
+```bash
+mise run bmad:retrigger-pr-checks -- <pr-number> --dry-run
+```
+
+This helper emits JSON with:
+- target repo + branch,
+- dispatch status (`dispatch_exit`, `dispatch_stderr`),
+- follow-up commands to inspect check state.
+
+Use this before falling back to manual empty-commit retriggers.

--- a/ops/bmad/retrigger_pr_checks.py
+++ b/ops/bmad/retrigger_pr_checks.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Operator-safe PR check retrigger helper.
+
+Dispatches the CI workflow for the head ref of a pull request without pushing a
+new commit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+
+def run_json(cmd: list[str]) -> Any:
+    result = run(cmd)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "command failed")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid JSON output from command: {' '.join(cmd)}") from exc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Retrigger CI checks for a PR by dispatching workflow_dispatch on its head branch."
+    )
+    parser.add_argument("pr", type=int, help="Pull request number")
+    parser.add_argument(
+        "--workflow",
+        default="ci.yml",
+        help="Workflow file name to dispatch (default: ci.yml)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve target branch and print actions without dispatching",
+    )
+    args = parser.parse_args()
+
+    repo = run_json(["gh", "repo", "view", "--json", "nameWithOwner"])["nameWithOwner"]
+    pr = run_json(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(args.pr),
+            "--json",
+            "number,state,headRefName,url",
+        ]
+    )
+
+    payload: dict[str, Any] = {
+        "repository": repo,
+        "pr": pr["number"],
+        "pr_state": pr["state"],
+        "pr_url": pr["url"],
+        "head_ref": pr["headRefName"],
+        "workflow": args.workflow,
+        "dry_run": args.dry_run,
+        "dispatch_requested": False,
+        "dispatch_exit": None,
+        "dispatch_stderr": "",
+        "followup_commands": [
+            f"gh pr checks {args.pr}",
+            f"gh run list --workflow CI --branch {pr['headRefName']} --event workflow_dispatch --limit 3",
+        ],
+    }
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    dispatch = run(
+        [
+            "gh",
+            "api",
+            "-X",
+            "POST",
+            f"repos/{repo}/actions/workflows/{args.workflow}/dispatches",
+            "-f",
+            f"ref={pr['headRefName']}",
+        ]
+    )
+    payload["dispatch_requested"] = True
+    payload["dispatch_exit"] = dispatch.returncode
+    payload["dispatch_stderr"] = dispatch.stderr.strip()
+
+    if dispatch.returncode != 0:
+        print(json.dumps(payload, indent=2))
+        return dispatch.returncode
+
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as exc:
+        print(json.dumps({"error": str(exc)}))
+        raise SystemExit(1)

--- a/ops/smoketest/smoketest-bmad-retrigger-pr-checks.sh
+++ b/ops/smoketest/smoketest-bmad-retrigger-pr-checks.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Smoke test for ops/bmad/retrigger_pr_checks.py
+# Covers machine-readable JSON output contract in dry-run mode.
+
+set -euo pipefail
+
+BLOODBANK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${BLOODBANK_ROOT}"
+
+PR_NUMBER="${PR_NUMBER:-127}"
+
+retrigger_json="$(python3 ops/bmad/retrigger_pr_checks.py "${PR_NUMBER}" --dry-run)"
+
+python3 - <<'PY' "${retrigger_json}" "${PR_NUMBER}"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+pr_number = int(sys.argv[2])
+
+for key in [
+    "repository",
+    "pr",
+    "pr_state",
+    "pr_url",
+    "head_ref",
+    "workflow",
+    "dry_run",
+    "dispatch_requested",
+    "dispatch_exit",
+    "dispatch_stderr",
+    "followup_commands",
+]:
+    assert key in payload, payload
+
+assert payload["pr"] == pr_number, payload
+assert payload["workflow"] == "ci.yml", payload
+assert payload["dry_run"] is True, payload
+assert payload["dispatch_requested"] is False, payload
+assert payload["dispatch_exit"] is None, payload
+assert isinstance(payload["followup_commands"], list), payload
+assert payload["followup_commands"], payload
+PY
+
+echo "smoketest-bmad-retrigger-pr-checks: PASS"


### PR DESCRIPTION
## Summary
- add `ops/bmad/retrigger_pr_checks.py` to dispatch `ci.yml` on a PR head branch via `workflow_dispatch`
- enable `workflow_dispatch` on CI workflow so operators can retrigger checks without empty commits
- add docs + task wiring + dry-run smoketest contract for the new helper
- scaffold `_bmad_output/issue-128-execution.md` with verification evidence

## Verification
- `mise run smoketest:bmad-retrigger-pr-checks`
- `python3 -m py_compile ops/bmad/retrigger_pr_checks.py`

Closes #128