### PR TITLE
docs: harden BMAD loops against gh projectCards deprecation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ alongside each service, using Holyfields-generated publishers.
   - failing check run URL
   - `gh run view <run-id> --log-failed` excerpt (error signature)
   - follow-up ticket URL when the fix is out of current PR scope
+- For GitHub CLI reliability fallbacks (`projectCards` deprecation class), use `ops/bmad/github-cli-reliability.md` and prefer `gh ... --json` or `gh api` REST paths in automation loops.
 - For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.

--- a/_bmad_output/issue-130-execution.md
+++ b/_bmad_output/issue-130-execution.md
@@ -1,0 +1,25 @@
+# Issue 130 — execution closeout
+
+## Ticket
+- Issue: #130
+- Title: Harden operator scripts against gh GraphQL projectCards deprecation failures
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added fallback runbook: `ops/bmad/github-cli-reliability.md`.
+- Updated `AGENTS.md` BMAD baseline to require `--json`/`gh api` fallback patterns for GraphQL deprecation failures.
+
+## Out of scope
+- Refactoring every existing operator helper to REST-only paths.
+
+## Verification evidence
+- `gh issue view 130 --json state,title,url` → issue open and reachable via JSON mode.
+- `mise run repo-health:artifact` → `_bmad_output/evidence/repo-health-20260515T094119Z.json`.
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/130
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- This ticket closes immediate loop reliability guidance; broader helper rewrites can be handled incrementally if deprecation failures recur.

--- a/ops/bmad/github-cli-reliability.md
+++ b/ops/bmad/github-cli-reliability.md
@@ -1,0 +1,43 @@
+# GitHub CLI reliability fallback (projectCards deprecation)
+
+Some `gh` command paths may fail with GraphQL classic-projects deprecation errors, e.g.:
+
+- `repository.issue.projectCards`
+- `repository.pullRequest.projectCards`
+
+Use these automation-safe patterns in BMAD loops.
+
+## Preferred command patterns
+
+### Issue/PR reads
+
+- Prefer explicit JSON field queries:
+
+```bash
+gh issue view <id> --json number,title,state,url,body
+gh pr view <id> --json number,title,state,url,headRefName,mergeStateStatus,statusCheckRollup
+```
+
+- If JSON path still fails, use REST directly:
+
+```bash
+gh api repos/<owner>/<repo>/issues/<id>
+gh api repos/<owner>/<repo>/pulls/<id>
+```
+
+### Issue/PR edits
+
+- Prefer REST patch for title/body edits (avoids GraphQL mutation path):
+
+```bash
+body="$(cat /tmp/body.md)"
+gh api repos/<owner>/<repo>/issues/<id> -X PATCH -f title='...' -f body="$body"
+gh api repos/<owner>/<repo>/pulls/<id> -X PATCH -f title='...' -f body="$body"
+```
+
+## Operational checklist
+
+1. Capture failing `gh` command + stderr in the ticket evidence.
+2. Retry using `--json` field-limited read.
+3. Fall back to `gh api` REST for reads/edits.
+4. Keep loop moving; do not block BMAD closeout on GraphQL-only paths.


### PR DESCRIPTION
## Summary
- add `ops/bmad/github-cli-reliability.md` with `gh --json` + `gh api` fallback patterns for projectCards deprecation failures
- update `AGENTS.md` BMAD baseline to point operators to the reliability fallback runbook
- scaffold `_bmad_output/issue-130-execution.md` with evidence and links

## Verification
- `gh issue view 130 --json state,title,url`
- `mise run repo-health:artifact`

Closes #130
