### PR TITLE
docs: harden BMAD GitHub body authoring against shell interpolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,8 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-closeout-loop` | local validation for unified closeout helper JSON/evidence fields |
 | `mise run smoketest:bmad-merge-pr-safe` | local validation for safe merge helper JSON/cleanup follow-up fields |
 | `mise run smoketest:bmad-retrigger-pr-checks` | local validation for PR check retrigger helper JSON contract (dry-run path) |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks, fail-fast) |
+| `mise run smoketest:bmad-github-body-safety` | guardrail grep for risky inline `gh ... --body "..."` patterns in BMAD operator docs/scripts |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline
@@ -82,6 +83,7 @@ alongside each service, using Holyfields-generated publishers.
   - `gh run view <run-id> --log-failed` excerpt (error signature)
   - follow-up ticket URL when the fix is out of current PR scope
 - For GitHub CLI reliability fallbacks (`projectCards` deprecation class), use `ops/bmad/github-cli-reliability.md` and prefer `gh ... --json` or `gh api` REST paths in automation loops.
+- For shell-safe issue/PR markdown composition, use `ops/bmad/github-body-authoring.md` and prefer `--body-file`/file-backed REST payloads over inline `--body "..."`.
 - For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.

--- a/_bmad_output/issue-132-execution.md
+++ b/_bmad_output/issue-132-execution.md
@@ -1,0 +1,26 @@
+# Issue 132 — execution closeout
+
+## Ticket
+- Issue: #132
+- Title: Harden BMAD GitHub body composition against shell interpolation hazards
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added shell-safe runbook `ops/bmad/github-body-authoring.md` with `--body-file` and file-backed REST patch patterns.
+- Updated `ops/bmad/clean-worktree-automation.md` to use `gh pr create --body-file` instead of inline `--body`.
+- Added guardrail smoke test `ops/smoketest/smoketest-bmad-github-body-safety.sh` and wired it into `mise` + `AGENTS.md` task docs.
+
+## Out of scope
+- Full historical rewrite of all non-BMAD docs outside `ops/bmad`.
+
+## Verification evidence
+- `mise run smoketest:bmad-github-body-safety` → `PASS`
+- `rg -n "gh (issue create|pr create|pr edit|issue edit).*(--body(=| )\")" ops/bmad` → no matches
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/132
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- This specifically hardens BMAD operator paths where cron automation composes markdown-heavy bodies.

--- a/mise.toml
+++ b/mise.toml
@@ -132,9 +132,13 @@ run = "bash ops/smoketest/smoketest-bmad-merge-pr-safe.sh"
 description = "Local smoke test for PR check retrigger helper JSON contract (dry-run)"
 run = "bash ops/smoketest/smoketest-bmad-retrigger-pr-checks.sh"
 
+[tasks."smoketest:bmad-github-body-safety"]
+description = "Guard against risky inline gh --body usage in BMAD operator docs/scripts"
+run = "bash ops/smoketest/smoketest-bmad-github-body-safety.sh"
+
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/clean-worktree-automation.md
+++ b/ops/bmad/clean-worktree-automation.md
@@ -39,7 +39,14 @@ git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin fix/issue-<id>-<slug>
 
-gh pr create --base main --head fix/issue-<id>-<slug> --title "<title>" --body "Closes #<id>"
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+- <what changed>
+
+Closes #<id>
+EOF
+
+gh pr create --base main --head fix/issue-<id>-<slug> --title "<title>" --body-file /tmp/pr-body.md
 
 # optional cleanup after merge
 cd -

--- a/ops/bmad/github-body-authoring.md
+++ b/ops/bmad/github-body-authoring.md
@@ -1,0 +1,47 @@
+# Safe GitHub body authoring for BMAD automation
+
+Avoid inline `--body "..."` when markdown may include backticks or shell-significant characters.
+
+## Preferred patterns
+
+### Create issue
+
+```bash
+cat > /tmp/issue-body.md <<'EOF'
+## Summary
+...
+EOF
+
+gh issue create \
+  --title "<title>" \
+  --body-file /tmp/issue-body.md
+```
+
+### Create PR
+
+```bash
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+...
+
+Closes #<id>
+EOF
+
+gh pr create \
+  --base main \
+  --head fix/issue-<id>-<slug> \
+  --title "<title>" \
+  --body-file /tmp/pr-body.md
+```
+
+### Edit issue/PR body reliably
+
+```bash
+body="$(cat /tmp/body.md)"
+gh api repos/<owner>/<repo>/issues/<id> -X PATCH -f body="$body"
+gh api repos/<owner>/<repo>/pulls/<id> -X PATCH -f body="$body"
+```
+
+## Rule of thumb
+
+If body text is longer than a short sentence, use `--body-file` (or REST patch from a file-backed variable).

--- a/ops/smoketest/smoketest-bmad-github-body-safety.sh
+++ b/ops/smoketest/smoketest-bmad-github-body-safety.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Guard against risky inline gh body composition in BMAD operator docs/scripts.
+
+set -euo pipefail
+
+BLOODBANK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${BLOODBANK_ROOT}"
+
+# Inline --body with quoted markdown is fragile in shell automation loops.
+pattern='gh (issue create|pr create|pr edit|issue edit).*(--body(=| )")'
+
+if rg -n "$pattern" ops/bmad >/tmp/bmad-gh-body-safety-hits.txt; then
+  echo "Unsafe inline gh --body pattern detected:" >&2
+  cat /tmp/bmad-gh-body-safety-hits.txt >&2
+  exit 1
+fi
+
+echo "smoketest-bmad-github-body-safety: PASS"


### PR DESCRIPTION
## Summary
- add `ops/bmad/github-body-authoring.md` with shell-safe `--body-file` and file-backed REST patch patterns
- replace inline `gh pr create --body` example in clean-worktree BMAD doc with `--body-file`
- add guardrail smoke test `smoketest:bmad-github-body-safety` and wire it into `mise` + `AGENTS.md`
- scaffold `_bmad_output/issue-132-execution.md` for ticket closeout evidence

## Verification
- `mise run smoketest:bmad-github-body-safety`
- `rg -n "gh (issue create|pr create|pr edit|issue edit).*(--body(=| )\")" ops/bmad`

Closes #132
