### PR TITLE
fix: make merge_pr_safe local cleanup idempotent

### DIFF
--- a/_bmad_output/issue-134-execution.md
+++ b/_bmad_output/issue-134-execution.md
@@ -1,0 +1,26 @@
+# Issue 134 — execution closeout
+
+## Ticket
+- Issue: #134
+- Title: Make merge_pr_safe cleanup follow-up idempotent for missing local branches
+- Owner: hermes (pilot)
+
+## Scope completed
+- Updated `ops/bmad/merge_pr_safe.py` to make local branch cleanup idempotent when branch is already absent.
+- Added explicit cleanup status field `cleanup.local_branch_status` with values `{already_absent, deleted, failed, not_applicable}`.
+- Updated merge helper smoke contract to validate new status semantics.
+
+## Out of scope
+- Additional closeout-loop/reporting changes outside merge helper JSON contract.
+
+## Verification evidence
+- `mise run smoketest:bmad-merge-pr-safe` → `PASS`
+- `python3 -m py_compile ops/bmad/merge_pr_safe.py` → success
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/134
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- This removes noisy follow-up `git branch -d ...` guidance when branch is already missing locally.

--- a/ops/bmad/merge_pr_safe.py
+++ b/ops/bmad/merge_pr_safe.py
@@ -37,6 +37,15 @@ def gh_pr_view(pr: str) -> dict[str, object]:
     return json.loads(cp.stdout)
 
 
+def branch_exists_local(branch: str) -> bool:
+    cp = subprocess.run(
+        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        text=True,
+        capture_output=True,
+    )
+    return cp.returncode == 0
+
+
 def worktree_paths_for_branch(branch: str) -> list[str]:
     cp = subprocess.run(
         ["git", "worktree", "list", "--porcelain"],
@@ -93,6 +102,7 @@ def main() -> int:
         "merge_command_stderr": merge.err,
         "head_branch": head_branch,
         "cleanup": {
+            "local_branch_status": "not_applicable",
             "local_branch_deleted": None,
             "linked_worktrees": [],
             "followup_commands": [],
@@ -105,18 +115,24 @@ def main() -> int:
 
     cleanup = report["cleanup"]
     if head_branch:
-        del_res = run("git", "branch", "-d", head_branch)
-        if del_res.code == 0:
+        if not branch_exists_local(head_branch):
+            cleanup["local_branch_status"] = "already_absent"
             cleanup["local_branch_deleted"] = True
         else:
-            cleanup["local_branch_deleted"] = False
-            paths = worktree_paths_for_branch(head_branch)
-            cleanup["linked_worktrees"] = paths
-            followups: list[str] = []
-            for path in paths:
-                followups.append(f"git worktree remove {path}")
-            followups.append(f"git branch -d {head_branch}")
-            cleanup["followup_commands"] = followups
+            del_res = run("git", "branch", "-d", head_branch)
+            if del_res.code == 0:
+                cleanup["local_branch_status"] = "deleted"
+                cleanup["local_branch_deleted"] = True
+            else:
+                cleanup["local_branch_status"] = "failed"
+                cleanup["local_branch_deleted"] = False
+                paths = worktree_paths_for_branch(head_branch)
+                cleanup["linked_worktrees"] = paths
+                followups: list[str] = []
+                for path in paths:
+                    followups.append(f"git worktree remove {path}")
+                followups.append(f"git branch -d {head_branch}")
+                cleanup["followup_commands"] = followups
 
     # Success even if merge command failed, as long as PR is confirmed merged.
     # This covers linked-worktree local deletion failures from gh merge.

--- a/ops/smoketest/smoketest-bmad-merge-pr-safe.sh
+++ b/ops/smoketest/smoketest-bmad-merge-pr-safe.sh
@@ -37,10 +37,20 @@ if payload["head_branch"] is not None:
 
 cleanup = payload["cleanup"]
 assert isinstance(cleanup, dict), payload
-for key in ["local_branch_deleted", "linked_worktrees", "followup_commands"]:
+for key in [
+    "local_branch_status",
+    "local_branch_deleted",
+    "linked_worktrees",
+    "followup_commands",
+]:
     assert key in cleanup, payload
+assert cleanup["local_branch_status"] in {"not_applicable", "already_absent", "deleted", "failed"}, payload
 assert isinstance(cleanup["linked_worktrees"], list), payload
 assert isinstance(cleanup["followup_commands"], list), payload
+if cleanup["local_branch_status"] in {"already_absent", "deleted"}:
+    assert cleanup["local_branch_deleted"] is True, payload
+if cleanup["local_branch_status"] == "failed":
+    assert cleanup["local_branch_deleted"] is False, payload
 PY
 
 echo "smoketest-bmad-merge-pr-safe: PASS"


### PR DESCRIPTION
## Summary
- make `ops/bmad/merge_pr_safe.py` local branch cleanup idempotent when the branch is already absent
- add explicit cleanup status field `cleanup.local_branch_status` (`already_absent|deleted|failed|not_applicable`)
- update `smoketest-bmad-merge-pr-safe` assertions for new cleanup contract
- scaffold `_bmad_output/issue-134-execution.md` with verification evidence

## Verification
- `mise run smoketest:bmad-merge-pr-safe`
- `python3 -m py_compile ops/bmad/merge_pr_safe.py`

Closes #134
