### PR TITLE
feat: expose normalized cleanup status in closeout loop output

### DIFF
--- a/_bmad_output/issue-136-execution.md
+++ b/_bmad_output/issue-136-execution.md
@@ -1,0 +1,28 @@
+# Issue 136 — execution closeout
+
+## Ticket
+- Issue: #136
+- Title: Expose normalized cleanup status in closeout_loop output
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added top-level normalized cleanup fields to `ops/bmad/closeout_loop.py`:
+  - `cleanup_local_branch_status`
+  - `cleanup_local_branch_deleted`
+- Kept backward-compatible `cleanup_followup_commands` + warning behavior.
+- Extended closeout-loop smoke assertions for normalized cleanup status values.
+
+## Out of scope
+- Additional dashboard/report consumers outside closeout-loop output contract.
+
+## Verification evidence
+- `mise run smoketest:bmad-closeout-loop` → `PASS`
+- `python3 -m py_compile ops/bmad/closeout_loop.py` → success
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/136
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Defaults to `cleanup_local_branch_status = "unknown"` when merge payload has no cleanup block.

--- a/ops/bmad/closeout_loop.py
+++ b/ops/bmad/closeout_loop.py
@@ -101,10 +101,17 @@ def main() -> int:
 
     warnings: list[str] = []
     cleanup_followups: list[str] = []
+    cleanup_local_branch_status = "unknown"
+    cleanup_local_branch_deleted: bool | None = None
     if merge_payload:
         cleanup = merge_payload.get("cleanup")
         if isinstance(cleanup, dict):
+            status = cleanup.get("local_branch_status")
+            if isinstance(status, str) and status:
+                cleanup_local_branch_status = status
             local_deleted = cleanup.get("local_branch_deleted")
+            if isinstance(local_deleted, bool) or local_deleted is None:
+                cleanup_local_branch_deleted = local_deleted
             if local_deleted is False:
                 warnings.append("local branch cleanup requires follow-up")
             cmds = cleanup.get("followup_commands")
@@ -125,6 +132,8 @@ def main() -> int:
         "drift_snapshot_ok": drift_ok,
         "merge": merge_payload,
         "drift": drift_payload,
+        "cleanup_local_branch_status": cleanup_local_branch_status,
+        "cleanup_local_branch_deleted": cleanup_local_branch_deleted,
         "cleanup_followup_commands": cleanup_followups,
         "warnings": warnings,
         "overall_status": "ok" if (merged and drift_ok) else "error",

--- a/ops/smoketest/smoketest-bmad-closeout-loop.sh
+++ b/ops/smoketest/smoketest-bmad-closeout-loop.sh
@@ -21,6 +21,7 @@ assert payload["overall_status"] == "ok", payload
 assert payload["merged"] is True, payload
 assert payload["drift_snapshot_ok"] is True, payload
 assert payload["primary_repo_source"] == "cli", payload
+assert payload["cleanup_local_branch_status"] in {"unknown", "not_applicable", "already_absent", "deleted", "failed"}, payload
 assert isinstance(payload["cleanup_followup_commands"], list), payload
 assert isinstance(payload["merge"], dict), payload
 assert isinstance(payload["drift"], dict), payload


### PR DESCRIPTION
## Summary
- add normalized top-level cleanup fields in `ops/bmad/closeout_loop.py`:
  - `cleanup_local_branch_status`
  - `cleanup_local_branch_deleted`
- preserve existing `cleanup_followup_commands` + warning behavior for backward compatibility
- extend `smoketest-bmad-closeout-loop` assertions for the new cleanup status contract
- scaffold `_bmad_output/issue-136-execution.md` with verification evidence

## Verification
- `mise run smoketest:bmad-closeout-loop`
- `python3 -m py_compile ops/bmad/closeout_loop.py`

Closes #136
