### PR TITLE
feat: add closeout cleanup-status summary helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ alongside each service, using Holyfields-generated publishers.
 | `ISSUE_ID=<id> SLUG=<slug> mise run bmad:worktree-bootstrap` | bootstrap isolated clean worktree from `origin/main` for ticket loops |
 | `mise run bmad:pr-merge-safe -- <pr>` | safe squash merge + merged-state verification + cleanup follow-ups |
 | `mise run bmad:closeout-loop -- <pr> [--primary-repo <path>]` | unified closeout summary (merge+cleanup+drift evidence, JSON; defaults `PRIMARY_REPO` env then cwd) |
+| `mise run bmad:closeout-cleanup-summary -- [--evidence-dir <dir>] [--limit <n>]` | read-only summary of closeout artifact cleanup status fields for quick operator review |
 | `mise run bmad:retrigger-pr-checks -- <pr> [--workflow ci.yml] [--dry-run]` | dispatch CI workflow for PR head branch without no-op commit retriggers |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
@@ -66,7 +67,8 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-merge-pr-safe` | local validation for safe merge helper JSON/cleanup follow-up fields |
 | `mise run smoketest:bmad-retrigger-pr-checks` | local validation for PR check retrigger helper JSON contract (dry-run path) |
 | `mise run smoketest:bmad-github-body-safety` | guardrail grep for risky inline `gh ... --body "..."` patterns in BMAD operator docs/scripts |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety, fail-fast) |
+| `mise run smoketest:bmad-closeout-cleanup-summary` | local validation for closeout cleanup summary helper JSON output contract |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline
@@ -87,6 +89,7 @@ alongside each service, using Holyfields-generated publishers.
 - For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.
+- For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
 - If primary checkout is dirty/behind, use the dedicated clean-worktree automation path in `ops/bmad/clean-worktree-automation.md` (do not stash/discard unknown local changes).
 - Local OpenClaw hook scratch path (`services/agent-hooks/openclaw/`) is intentionally treated as operator-local and excluded from repo tracking.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.

--- a/_bmad_output/issue-138-execution.md
+++ b/_bmad_output/issue-138-execution.md
@@ -1,0 +1,26 @@
+# Issue 138 — execution closeout
+
+## Ticket
+- Issue: #138
+- Title: Add closeout artifact cleanup-status summary helper
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added read-only helper: `ops/bmad/closeout_cleanup_summary.py`.
+- Added smoke test: `ops/smoketest/smoketest-bmad-closeout-cleanup-summary.sh`.
+- Wired new tasks + docs updates in `mise.toml`, `AGENTS.md`, and `ops/bmad/closeout-cleanup-summary.md`.
+
+## Out of scope
+- Backfilling historical closeout artifacts into `_bmad_output/evidence`.
+
+## Verification evidence
+- `mise run smoketest:bmad-closeout-cleanup-summary` → `PASS`
+- `mise run bmad:closeout-cleanup-summary -- --limit 5` → JSON output contract validated on live evidence dir (`count: 0` currently)
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/138
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Helper supports both new top-level cleanup fields and legacy nested merge cleanup shape.

--- a/mise.toml
+++ b/mise.toml
@@ -76,6 +76,10 @@ run = "python3 ops/bmad/merge_pr_safe.py"
 description = "Unified closeout helper: safe merge + cleanup follow-ups + primary drift snapshot"
 run = "python3 ops/bmad/closeout_loop.py"
 
+[tasks."bmad:closeout-cleanup-summary"]
+description = "Read-only summary of closeout artifact cleanup status fields"
+run = "python3 ops/bmad/closeout_cleanup_summary.py"
+
 [tasks."bmad:retrigger-pr-checks"]
 description = "Dispatch CI workflow for a PR head branch (no empty commit retrigger)"
 run = "python3 ops/bmad/retrigger_pr_checks.py"
@@ -136,9 +140,13 @@ run = "bash ops/smoketest/smoketest-bmad-retrigger-pr-checks.sh"
 description = "Guard against risky inline gh --body usage in BMAD operator docs/scripts"
 run = "bash ops/smoketest/smoketest-bmad-github-body-safety.sh"
 
+[tasks."smoketest:bmad-closeout-cleanup-summary"]
+description = "Local smoke test for closeout cleanup summary helper JSON output"
+run = "bash ops/smoketest/smoketest-bmad-closeout-cleanup-summary.sh"
+
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/closeout-cleanup-summary.md
+++ b/ops/bmad/closeout-cleanup-summary.md
@@ -1,0 +1,21 @@
+# Closeout cleanup status summary
+
+Use this read-only helper to quickly inspect cleanup quality across recent closeout artifacts.
+
+```bash
+mise run bmad:closeout-cleanup-summary -- --limit 10
+```
+
+Optional custom evidence directory:
+
+```bash
+mise run bmad:closeout-cleanup-summary -- --evidence-dir _bmad_output/evidence --limit 25
+```
+
+Output includes per-artifact:
+- PR id (`pr`)
+- overall closeout status (`overall_status`)
+- normalized cleanup status (`cleanup_local_branch_status`)
+- local-branch deletion signal (`cleanup_local_branch_deleted`)
+- follow-up command count (`cleanup_followup_count`)
+- warning count (`warning_count`)

--- a/ops/bmad/closeout_cleanup_summary.py
+++ b/ops/bmad/closeout_cleanup_summary.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Summarize BMAD closeout artifacts with cleanup status highlights."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _extract_cleanup(payload: dict[str, Any]) -> tuple[str, bool | None, int]:
+    status = payload.get("cleanup_local_branch_status")
+    deleted = payload.get("cleanup_local_branch_deleted")
+    followups = payload.get("cleanup_followup_commands")
+
+    if not isinstance(status, str) or not status:
+        merge = payload.get("merge")
+        if isinstance(merge, dict):
+            cleanup = merge.get("cleanup")
+            if isinstance(cleanup, dict):
+                nested_status = cleanup.get("local_branch_status")
+                if isinstance(nested_status, str) and nested_status:
+                    status = nested_status
+                nested_deleted = cleanup.get("local_branch_deleted")
+                if isinstance(nested_deleted, bool) or nested_deleted is None:
+                    deleted = nested_deleted
+                if not isinstance(followups, list):
+                    nested_followups = cleanup.get("followup_commands")
+                    if isinstance(nested_followups, list):
+                        followups = nested_followups
+
+    if not isinstance(status, str) or not status:
+        status = "unknown"
+
+    if not isinstance(deleted, bool) and deleted is not None:
+        deleted = None
+
+    followup_count = len(followups) if isinstance(followups, list) else 0
+    return status, deleted, followup_count
+
+
+def summarize(evidence_dir: Path, limit: int) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+
+    for path in sorted(evidence_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True):
+        try:
+            payload = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        if not isinstance(payload, dict):
+            continue
+
+        if "overall_status" not in payload and "merge" not in payload:
+            continue
+
+        status, deleted, followup_count = _extract_cleanup(payload)
+
+        if status == "unknown" and "cleanup_local_branch_status" not in payload and not isinstance(payload.get("merge"), dict):
+            continue
+
+        warnings = payload.get("warnings")
+        warning_count = len(warnings) if isinstance(warnings, list) else 0
+
+        items.append(
+            {
+                "artifact": str(path),
+                "pr": payload.get("pr"),
+                "overall_status": payload.get("overall_status"),
+                "merged": payload.get("merged"),
+                "cleanup_local_branch_status": status,
+                "cleanup_local_branch_deleted": deleted,
+                "cleanup_followup_count": followup_count,
+                "warning_count": warning_count,
+            }
+        )
+
+        if len(items) >= limit:
+            break
+
+    return {
+        "evidence_dir": str(evidence_dir.resolve()),
+        "count": len(items),
+        "items": items,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize closeout artifact cleanup status")
+    parser.add_argument("--evidence-dir", default="_bmad_output/evidence", help="Directory containing closeout JSON artifacts")
+    parser.add_argument("--limit", type=int, default=10, help="Maximum artifact rows to emit")
+    args = parser.parse_args()
+
+    evidence_dir = Path(args.evidence_dir)
+    if not evidence_dir.exists() or not evidence_dir.is_dir():
+        print(json.dumps({"error": f"evidence dir not found: {evidence_dir}"}, indent=2))
+        return 1
+
+    limit = max(1, args.limit)
+    report = summarize(evidence_dir, limit)
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/smoketest/smoketest-bmad-closeout-cleanup-summary.sh
+++ b/ops/smoketest/smoketest-bmad-closeout-cleanup-summary.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Smoke test for ops/bmad/closeout_cleanup_summary.py
+
+set -euo pipefail
+
+BLOODBANK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${BLOODBANK_ROOT}"
+
+TMP_EVIDENCE_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_EVIDENCE_DIR}"
+}
+trap cleanup EXIT
+
+cat > "${TMP_EVIDENCE_DIR}/closeout-loop-a.json" <<'JSON'
+{
+  "pr": 101,
+  "overall_status": "ok",
+  "merged": true,
+  "cleanup_local_branch_status": "already_absent",
+  "cleanup_local_branch_deleted": true,
+  "cleanup_followup_commands": [],
+  "warnings": []
+}
+JSON
+
+cat > "${TMP_EVIDENCE_DIR}/closeout-loop-b.json" <<'JSON'
+{
+  "pr": 99,
+  "overall_status": "ok",
+  "merged": true,
+  "merge": {
+    "cleanup": {
+      "local_branch_status": "failed",
+      "local_branch_deleted": false,
+      "followup_commands": ["git branch -d fix/issue-99"]
+    }
+  },
+  "warnings": ["local branch cleanup requires follow-up"]
+}
+JSON
+
+summary_json="$(python3 ops/bmad/closeout_cleanup_summary.py --evidence-dir "${TMP_EVIDENCE_DIR}" --limit 5)"
+
+python3 - <<'PY' "${summary_json}"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+assert payload["count"] == 2, payload
+assert isinstance(payload["items"], list), payload
+
+items = payload["items"]
+first = items[0]
+second = items[1]
+
+assert first["cleanup_local_branch_status"] in {"already_absent", "failed"}, payload
+assert second["cleanup_local_branch_status"] in {"already_absent", "failed"}, payload
+
+by_pr = {row["pr"]: row for row in items}
+assert by_pr[101]["cleanup_local_branch_status"] == "already_absent", payload
+assert by_pr[101]["cleanup_followup_count"] == 0, payload
+assert by_pr[99]["cleanup_local_branch_status"] == "failed", payload
+assert by_pr[99]["cleanup_followup_count"] == 1, payload
+assert by_pr[99]["warning_count"] == 1, payload
+PY
+
+echo "smoketest-bmad-closeout-cleanup-summary: PASS"


### PR DESCRIPTION
## Summary
- add read-only closeout artifact summary helper `ops/bmad/closeout_cleanup_summary.py`
- surface normalized cleanup status, follow-up count, and warning count across recent artifacts
- add smoke test `smoketest-bmad-closeout-cleanup-summary` and wire tasks/docs (`mise.toml`, `AGENTS.md`, `ops/bmad/closeout-cleanup-summary.md`)
- scaffold `_bmad_output/issue-138-execution.md` for ticket evidence

## Verification
- `mise run smoketest:bmad-closeout-cleanup-summary`
- `python3 -m py_compile ops/bmad/closeout_cleanup_summary.py`
- `mise run bmad:closeout-cleanup-summary -- --limit 5`

Closes #138
