### PR TITLE
feat: persist closeout-loop artifacts for cleanup summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,8 @@ alongside each service, using Holyfields-generated publishers.
 | `ISSUE_ID=<id> SLUG=<slug> mise run bmad:worktree-bootstrap` | bootstrap isolated clean worktree from `origin/main` for ticket loops |
 | `mise run bmad:pr-merge-safe -- <pr>` | safe squash merge + merged-state verification + cleanup follow-ups |
 | `mise run bmad:closeout-loop -- <pr> [--primary-repo <path>]` | unified closeout summary (merge+cleanup+drift evidence, JSON; defaults `PRIMARY_REPO` env then cwd) |
-| `mise run bmad:closeout-cleanup-summary -- [--evidence-dir <dir>] [--limit <n>]` | read-only summary of closeout artifact cleanup status fields for quick operator review |
+| `mise run bmad:closeout-loop:artifact -- <pr> [--primary-repo <path>]` | same as closeout-loop, plus timestamped artifact write to `_bmad_output/evidence/closeout/` |
+| `mise run bmad:closeout-cleanup-summary -- [--evidence-dir <dir>] [--limit <n>]` | read-only summary of closeout artifact cleanup status fields for quick operator review (defaults to `_bmad_output/evidence/closeout`) |
 | `mise run bmad:retrigger-pr-checks -- <pr> [--workflow ci.yml] [--dry-run]` | dispatch CI workflow for PR head branch without no-op commit retriggers |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
@@ -68,7 +69,8 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-retrigger-pr-checks` | local validation for PR check retrigger helper JSON contract (dry-run path) |
 | `mise run smoketest:bmad-github-body-safety` | guardrail grep for risky inline `gh ... --body "..."` patterns in BMAD operator docs/scripts |
 | `mise run smoketest:bmad-closeout-cleanup-summary` | local validation for closeout cleanup summary helper JSON output contract |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary, fail-fast) |
+| `mise run smoketest:bmad-closeout-artifact-summary` | local validation for closeout artifact write path + summary visibility contract |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline

--- a/_bmad_output/issue-140-execution.md
+++ b/_bmad_output/issue-140-execution.md
@@ -1,0 +1,27 @@
+# Issue 140 — execution closeout
+
+## Ticket
+- Issue: #140
+- Title: Persist closeout-loop artifacts so cleanup summary has live data
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added persistent artifact path support to `ops/bmad/closeout_loop.py` via `--out`.
+- Added artifact wrapper task/script `bmad:closeout-loop:artifact` (`ops/bmad/closeout_loop_artifact.sh`) writing to `_bmad_output/evidence/closeout/`.
+- Updated summary helper default directory to `_bmad_output/evidence/closeout`.
+- Added artifact+summary smoke coverage (`smoketest-bmad-closeout-artifact-summary`) and task/docs wiring (`mise.toml`, `AGENTS.md`, `ops/bmad/closeout-cleanup-summary.md`).
+
+## Out of scope
+- Historical backfill of all prior closeout runs.
+
+## Verification evidence
+- `mise run smoketest:bmad-closeout-artifact-summary` → `PASS`
+- `mise run bmad:closeout-loop:artifact -- 139` + `mise run bmad:closeout-cleanup-summary -- --limit 5` → summary now returns `count: 1` with live artifact item
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/140
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Artifacted closeout run during validation is read-only from a merge perspective (PR already merged) but intentionally records current drift status snapshot.

--- a/mise.toml
+++ b/mise.toml
@@ -76,6 +76,10 @@ run = "python3 ops/bmad/merge_pr_safe.py"
 description = "Unified closeout helper: safe merge + cleanup follow-ups + primary drift snapshot"
 run = "python3 ops/bmad/closeout_loop.py"
 
+[tasks."bmad:closeout-loop:artifact"]
+description = "Run closeout loop and persist timestamped JSON artifact under _bmad_output/evidence/closeout"
+run = "bash ops/bmad/closeout_loop_artifact.sh"
+
 [tasks."bmad:closeout-cleanup-summary"]
 description = "Read-only summary of closeout artifact cleanup status fields"
 run = "python3 ops/bmad/closeout_cleanup_summary.py"
@@ -144,9 +148,13 @@ run = "bash ops/smoketest/smoketest-bmad-github-body-safety.sh"
 description = "Local smoke test for closeout cleanup summary helper JSON output"
 run = "bash ops/smoketest/smoketest-bmad-closeout-cleanup-summary.sh"
 
+[tasks."smoketest:bmad-closeout-artifact-summary"]
+description = "Local smoke test for closeout artifact write + summary visibility"
+run = "bash ops/smoketest/smoketest-bmad-closeout-artifact-summary.sh"
+
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/closeout-cleanup-summary.md
+++ b/ops/bmad/closeout-cleanup-summary.md
@@ -2,6 +2,14 @@
 
 Use this read-only helper to quickly inspect cleanup quality across recent closeout artifacts.
 
+First, generate closeout artifacts while running merges:
+
+```bash
+mise run bmad:closeout-loop:artifact -- <pr-number-or-url>
+```
+
+Then summarize (defaults to `_bmad_output/evidence/closeout`):
+
 ```bash
 mise run bmad:closeout-cleanup-summary -- --limit 10
 ```

--- a/ops/bmad/closeout_cleanup_summary.py
+++ b/ops/bmad/closeout_cleanup_summary.py
@@ -88,7 +88,11 @@ def summarize(evidence_dir: Path, limit: int) -> dict[str, Any]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Summarize closeout artifact cleanup status")
-    parser.add_argument("--evidence-dir", default="_bmad_output/evidence", help="Directory containing closeout JSON artifacts")
+    parser.add_argument(
+        "--evidence-dir",
+        default="_bmad_output/evidence/closeout",
+        help="Directory containing closeout JSON artifacts",
+    )
     parser.add_argument("--limit", type=int, default=10, help="Maximum artifact rows to emit")
     args = parser.parse_args()
 

--- a/ops/bmad/closeout_loop.py
+++ b/ops/bmad/closeout_loop.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 
 def _run_json(command: list[str]) -> tuple[int, dict[str, object] | None, str, str]:
@@ -50,6 +51,15 @@ def _resolve_primary_repo(cli_value: str | None) -> tuple[Path, str]:
     return Path.cwd(), "cwd"
 
 
+def _emit(report: dict[str, Any], out: str | None) -> None:
+    rendered = json.dumps(report, indent=2)
+    print(rendered)
+    if out:
+        out_path = Path(out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(rendered + "\n")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Unified BMAD closeout helper")
     parser.add_argument("pr", help="PR number or URL")
@@ -57,31 +67,28 @@ def main() -> int:
         "--primary-repo",
         help="Path to primary checkout for read-only drift evidence snapshot (optional: defaults PRIMARY_REPO env, then cwd)",
     )
+    parser.add_argument("--out", help="Optional path to also write JSON report")
     args = parser.parse_args()
 
     primary_repo, primary_repo_source = _resolve_primary_repo(args.primary_repo)
 
     if not _is_git_repo(primary_repo):
-        print(
-            json.dumps(
-                {
-                    "pr": args.pr,
-                    "primary_repo": str(primary_repo.resolve()),
-                    "primary_repo_source": primary_repo_source,
-                    "overall_status": "error",
-                    "warnings": ["resolved primary repo is not a git worktree"],
-                    "diagnostics": {
-                        "merge_rc": None,
-                        "drift_rc": None,
-                        "merge_stderr": "",
-                        "drift_stderr": "",
-                        "merge_stdout_raw": None,
-                        "drift_stdout_raw": None,
-                    },
-                },
-                indent=2,
-            )
-        )
+        report = {
+            "pr": args.pr,
+            "primary_repo": str(primary_repo.resolve()),
+            "primary_repo_source": primary_repo_source,
+            "overall_status": "error",
+            "warnings": ["resolved primary repo is not a git worktree"],
+            "diagnostics": {
+                "merge_rc": None,
+                "drift_rc": None,
+                "merge_stderr": "",
+                "drift_stderr": "",
+                "merge_stdout_raw": None,
+                "drift_stdout_raw": None,
+            },
+        }
+        _emit(report, args.out)
         return 1
 
     merge_cmd = ["python3", "ops/bmad/merge_pr_safe.py", args.pr]
@@ -147,7 +154,7 @@ def main() -> int:
         },
     }
 
-    print(json.dumps(report, indent=2))
+    _emit(report, args.out)
     return 0 if (merged and drift_ok) else 1
 
 

--- a/ops/bmad/closeout_loop_artifact.sh
+++ b/ops/bmad/closeout_loop_artifact.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -lt 1 ]]; then
+  echo "usage: $0 <pr-number-or-url> [closeout-loop args...]" >&2
+  exit 1
+fi
+
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+out="_bmad_output/evidence/closeout/closeout-loop-${ts}.json"
+mkdir -p "$(dirname "$out")"
+
+python3 ops/bmad/closeout_loop.py "$@" --out "$out"
+echo "$out"

--- a/ops/smoketest/smoketest-bmad-closeout-artifact-summary.sh
+++ b/ops/smoketest/smoketest-bmad-closeout-artifact-summary.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Smoke test for closeout artifact writing + cleanup summary visibility.
+
+set -euo pipefail
+
+BLOODBANK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${BLOODBANK_ROOT}"
+
+MERGED_PR="${MERGED_PR:-139}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+OUT_PATH="${TMP_DIR}/closeout-loop-test.json"
+python3 ops/bmad/closeout_loop.py "${MERGED_PR}" --out "${OUT_PATH}" >/tmp/closeout-loop-smoke.json
+
+[[ -f "${OUT_PATH}" ]] || { echo "missing closeout artifact" >&2; exit 1; }
+
+summary_json="$(python3 ops/bmad/closeout_cleanup_summary.py --evidence-dir "${TMP_DIR}" --limit 5)"
+python3 - <<'PY' "${summary_json}" "${OUT_PATH}"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+out_path = sys.argv[2]
+
+assert payload["count"] == 1, payload
+item = payload["items"][0]
+assert item["artifact"] == out_path, payload
+assert item["cleanup_local_branch_status"] in {"already_absent", "deleted", "failed", "not_applicable", "unknown"}, payload
+PY
+
+echo "smoketest-bmad-closeout-artifact-summary: PASS"


### PR DESCRIPTION
## Summary
- add `--out` support to `ops/bmad/closeout_loop.py` for persistent JSON report writes
- add `bmad:closeout-loop:artifact` via `ops/bmad/closeout_loop_artifact.sh` to write timestamped artifacts under `_bmad_output/evidence/closeout/`
- default `bmad:closeout-cleanup-summary` to `_bmad_output/evidence/closeout` so current closeout artifacts are visible
- add smoke coverage for artifact write + summary visibility (`smoketest-bmad-closeout-artifact-summary`)
- update BMAD docs/task tables and scaffold `_bmad_output/issue-140-execution.md`

## Verification
- `mise run smoketest:bmad-closeout-artifact-summary`
- `mise run smoketest:bmad-closeout-cleanup-summary`
- `python3 -m py_compile ops/bmad/closeout_loop.py ops/bmad/closeout_cleanup_summary.py`
- `mise run bmad:closeout-loop:artifact -- 139`
- `mise run bmad:closeout-cleanup-summary -- --limit 5`

Closes #140
