### PR TITLE
chore: keep closeout evidence artifacts out of git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ htmlcov/
 
 # BMAD generated evidence artifacts
 _bmad_output/evidence/repo-health-*.json
+_bmad_output/evidence/closeout/*.json
 
 # Local OpenClaw hook workspace artifacts (operator-local; not project source)
 /services/agent-hooks/openclaw/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ alongside each service, using Holyfields-generated publishers.
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
+- Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.
 - If primary checkout is dirty/behind, use the dedicated clean-worktree automation path in `ops/bmad/clean-worktree-automation.md` (do not stash/discard unknown local changes).
 - Local OpenClaw hook scratch path (`services/agent-hooks/openclaw/`) is intentionally treated as operator-local and excluded from repo tracking.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.

--- a/_bmad_output/issue-142-execution.md
+++ b/_bmad_output/issue-142-execution.md
@@ -1,0 +1,25 @@
+# Issue 142 — execution closeout
+
+## Ticket
+- Issue: #142
+- Title: Prevent closeout evidence artifacts from dirtying primary checkout
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added ignore rule for runtime closeout artifacts: `_bmad_output/evidence/closeout/*.json`.
+- Updated BMAD baseline docs (`AGENTS.md`) to mark closeout evidence JSONs as operator-generated and intentionally git-ignored.
+
+## Out of scope
+- Relocating evidence storage outside repository paths.
+
+## Verification evidence
+- `git status --short --branch` before fix showed untracked `_bmad_output/evidence/`.
+- `git status --short --branch` after ignore update no longer shows `_bmad_output/evidence/` as untracked.
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/142
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Existing tracked BMAD docs/templates remain unaffected.


### PR DESCRIPTION
## Summary
- ignore runtime closeout evidence artifacts via `_bmad_output/evidence/closeout/*.json`
- document BMAD expectation in `AGENTS.md` that closeout evidence JSONs are operator-generated and git-ignored
- scaffold and populate `_bmad_output/issue-142-execution.md`

## Verification
- `git status --short --branch` no longer reports untracked `_bmad_output/evidence/` after ignore update
- `mise run repo-health:artifact`

Closes #142
