### PR TITLE
fix: retry transient gh connectivity in repo-health

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ alongside each service, using Holyfields-generated publishers.
 - For GitHub CLI reliability fallbacks (`projectCards` deprecation class), use `ops/bmad/github-cli-reliability.md` and prefer `gh ... --json` or `gh api` REST paths in automation loops.
 - For shell-safe issue/PR markdown composition, use `ops/bmad/github-body-authoring.md` and prefer `--body-file`/file-backed REST payloads over inline `--body "..."`.
 - For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
+- `repo-health` applies bounded retries for transient GitHub API connectivity errors on read-only `gh` status calls (`issue list`, `pr list`, `pr checks`).
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.

--- a/_bmad_output/issue-144-execution.md
+++ b/_bmad_output/issue-144-execution.md
@@ -1,0 +1,26 @@
+# Issue 144 — execution closeout
+
+## Ticket
+- Issue: #144
+- Title: Add bounded retry helper for transient gh API connectivity errors
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added bounded retry helper in `cli/bb.py` for read-only GitHub status calls used by `repo-health`.
+- Wired retries into `gh issue list`, `gh pr list`, and `gh pr checks` paths.
+- Updated BMAD reliability docs (`ops/bmad/github-cli-reliability.md`) and `AGENTS.md` guidance.
+
+## Out of scope
+- Mutating GitHub operations (`gh pr merge`, `gh issue create`, etc.) retry policy.
+
+## Verification evidence
+- `python3 -m py_compile cli/bb.py` → success
+- `mise run repo-health:artifact` → `_bmad_output/evidence/repo-health-20260515T132146Z.json`
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/144
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Retry behavior is bounded (3 attempts with short backoff) and only applied when stderr matches transient connectivity signatures.

--- a/cli/bb.py
+++ b/cli/bb.py
@@ -44,6 +44,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -232,6 +233,32 @@ def _run(root: Path, *argv: str) -> tuple[int, str, str]:
     return int(proc.returncode), proc.stdout.strip(), proc.stderr.strip()
 
 
+def _run_gh_readonly_with_retry(root: Path, *argv: str) -> tuple[int, str, str]:
+    """Run read-only gh commands with bounded retry on transient connectivity errors."""
+    attempts = 3
+    rc = 1
+    out = ""
+    err = ""
+
+    for attempt in range(1, attempts + 1):
+        rc, out, err = _run(root, *argv)
+        if rc == 0:
+            return rc, out, err
+
+        err_lower = err.lower()
+        transient = (
+            "error connecting to api.github.com" in err_lower
+            or "connection reset" in err_lower
+            or "timed out" in err_lower
+        )
+        if not transient or attempt == attempts:
+            return rc, out, err
+
+        time.sleep(0.5 * attempt)
+
+    return rc, out, err
+
+
 def _write_output(path_str: str, content: str) -> str | None:
     """Write command output to ``path_str``. Returns error text on failure."""
     try:
@@ -292,7 +319,7 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
             "worktree_dirty: ERROR (working tree is dirty but --require-clean-worktree was set)"
         )
 
-    rc_issue, issue_out, issue_err = _run(
+    rc_issue, issue_out, issue_err = _run_gh_readonly_with_retry(
         root,
         "gh",
         "issue",
@@ -318,7 +345,7 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
         cast_errors.append(f"issues_open: ERROR ({issue_err or 'gh issue list failed'})")
     snapshot["issues_open"] = issues
 
-    rc_pr, pr_out, pr_err = _run(
+    rc_pr, pr_out, pr_err = _run_gh_readonly_with_retry(
         root,
         "gh",
         "pr",
@@ -347,7 +374,9 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
     if prs:
         newest = sorted(prs, key=lambda x: str(x.get("updatedAt", "")), reverse=True)[0]
         pr_number = int(newest["number"])
-        rc_checks, checks_out, checks_err = _run(root, "gh", "pr", "checks", str(pr_number))
+        rc_checks, checks_out, checks_err = _run_gh_readonly_with_retry(
+            root, "gh", "pr", "checks", str(pr_number)
+        )
         if rc_checks in (0, 8) and checks_out:
             snapshot["latest_pr_checks"] = {
                 "pr_number": pr_number,

--- a/ops/bmad/github-cli-reliability.md
+++ b/ops/bmad/github-cli-reliability.md
@@ -35,6 +35,16 @@ gh api repos/<owner>/<repo>/issues/<id> -X PATCH -f title='...' -f body="$body"
 gh api repos/<owner>/<repo>/pulls/<id> -X PATCH -f title='...' -f body="$body"
 ```
 
+## Transient connectivity guard
+
+For read-only repo snapshots, `cli/bb.py repo-health` now applies bounded retry (3 attempts, short backoff) for transient `gh` connectivity failures (e.g. `error connecting to api.github.com`) on:
+
+- `gh issue list`
+- `gh pr list`
+- `gh pr checks`
+
+Use `mise run repo-health` / `mise run repo-health:artifact` as the preferred status path in automation loops.
+
 ## Operational checklist
 
 1. Capture failing `gh` command + stderr in the ticket evidence.


### PR DESCRIPTION
## Summary
- add bounded retry helper in `cli/bb.py` for transient GitHub API connectivity failures on read-only status calls
- apply retry path to `gh issue list`, `gh pr list`, and `gh pr checks` in `repo-health`
- update BMAD reliability docs (`ops/bmad/github-cli-reliability.md`) and `AGENTS.md`
- scaffold `_bmad_output/issue-144-execution.md`

## Verification
- `python3 -m py_compile cli/bb.py`
- `mise run repo-health:artifact`

Closes #144
