### PR TITLE
test: add coverage for repo-health gh retry behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,8 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-github-body-safety` | guardrail grep for risky inline `gh ... --body "..."` patterns in BMAD operator docs/scripts |
 | `mise run smoketest:bmad-closeout-cleanup-summary` | local validation for closeout cleanup summary helper JSON output contract |
 | `mise run smoketest:bmad-closeout-artifact-summary` | local validation for closeout artifact write path + summary visibility contract |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary, fail-fast) |
+| `mise run smoketest:bmad-repo-health-retry` | local validation for bounded transient retry behavior in `cli/bb.py repo-health` gh read paths |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline

--- a/_bmad_output/issue-146-execution.md
+++ b/_bmad_output/issue-146-execution.md
@@ -1,0 +1,26 @@
+# Issue 146 — execution closeout
+
+## Ticket
+- Issue: #146
+- Title: Add test coverage for repo-health transient gh retry behavior
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added deterministic smoke harness `ops/smoketest/smoketest-bmad-repo-health-retry.sh` for `cli/bb.py` retry semantics.
+- Coverage includes: transient retry-to-success, non-transient no-retry, and retry-bound exhaustion.
+- Wired task/docs updates in `mise.toml`, `AGENTS.md`, and `ops/bmad/github-cli-reliability.md`.
+
+## Out of scope
+- End-to-end network fault injection against live GitHub API.
+
+## Verification evidence
+- `mise run smoketest:bmad-repo-health-retry` → `PASS`
+- `python3 -m py_compile cli/bb.py` → success
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/146
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Test is stdlib-only and monkeypatches `_run`/`time.sleep` at module scope for deterministic behavior.

--- a/mise.toml
+++ b/mise.toml
@@ -152,9 +152,13 @@ run = "bash ops/smoketest/smoketest-bmad-closeout-cleanup-summary.sh"
 description = "Local smoke test for closeout artifact write + summary visibility"
 run = "bash ops/smoketest/smoketest-bmad-closeout-artifact-summary.sh"
 
+[tasks."smoketest:bmad-repo-health-retry"]
+description = "Local smoke test for repo-health transient gh retry behavior"
+run = "bash ops/smoketest/smoketest-bmad-repo-health-retry.sh"
+
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/github-cli-reliability.md
+++ b/ops/bmad/github-cli-reliability.md
@@ -45,6 +45,12 @@ For read-only repo snapshots, `cli/bb.py repo-health` now applies bounded retry 
 
 Use `mise run repo-health` / `mise run repo-health:artifact` as the preferred status path in automation loops.
 
+Local regression check:
+
+```bash
+mise run smoketest:bmad-repo-health-retry
+```
+
 ## Operational checklist
 
 1. Capture failing `gh` command + stderr in the ticket evidence.

--- a/ops/smoketest/smoketest-bmad-repo-health-retry.sh
+++ b/ops/smoketest/smoketest-bmad-repo-health-retry.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Smoke test for cli/bb.py transient gh retry helper behavior.
+
+set -euo pipefail
+
+BLOODBANK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${BLOODBANK_ROOT}"
+
+python3 - <<'PY'
+import cli.bb as bb
+
+orig_run = bb._run
+orig_sleep = bb.time.sleep
+
+try:
+    # Case 1: transient failures retry then succeed.
+    calls = []
+    sleeps = []
+    responses = [
+        (1, "", "error connecting to api.github.com"),
+        (1, "", "timed out"),
+        (0, "ok", ""),
+    ]
+
+    def fake_run_transient(root, *argv):
+        calls.append(argv)
+        return responses.pop(0)
+
+    bb._run = fake_run_transient
+    bb.time.sleep = lambda sec: sleeps.append(sec)
+
+    rc, out, err = bb._run_gh_readonly_with_retry(bb.bloodbank_root(), "gh", "issue", "list")
+    assert rc == 0 and out == "ok" and err == "", (rc, out, err)
+    assert len(calls) == 3, len(calls)
+    assert sleeps == [0.5, 1.0], sleeps
+
+    # Case 2: non-transient errors should not retry.
+    calls = []
+    sleeps = []
+
+    def fake_run_non_transient(root, *argv):
+        calls.append(argv)
+        return (1, "", "GraphQL: Projects (classic) is being deprecated")
+
+    bb._run = fake_run_non_transient
+    bb.time.sleep = lambda sec: sleeps.append(sec)
+
+    rc, out, err = bb._run_gh_readonly_with_retry(bb.bloodbank_root(), "gh", "pr", "list")
+    assert rc == 1 and "deprecated" in err.lower(), (rc, out, err)
+    assert len(calls) == 1, len(calls)
+    assert sleeps == [], sleeps
+
+    # Case 3: transient errors exhausted at retry bound.
+    calls = []
+    sleeps = []
+
+    def fake_run_exhausted(root, *argv):
+        calls.append(argv)
+        return (1, "", "error connecting to api.github.com")
+
+    bb._run = fake_run_exhausted
+    bb.time.sleep = lambda sec: sleeps.append(sec)
+
+    rc, out, err = bb._run_gh_readonly_with_retry(bb.bloodbank_root(), "gh", "pr", "checks", "1")
+    assert rc == 1 and "error connecting" in err.lower(), (rc, out, err)
+    assert len(calls) == 3, len(calls)
+    assert sleeps == [0.5, 1.0], sleeps
+
+finally:
+    bb._run = orig_run
+    bb.time.sleep = orig_sleep
+PY
+
+echo "smoketest-bmad-repo-health-retry: PASS"


### PR DESCRIPTION
## Summary
- add deterministic smoke harness `smoketest-bmad-repo-health-retry` for `cli/bb.py` transient gh retry behavior
- cover retry-to-success, non-transient no-retry, and bounded retry exhaustion paths
- wire task/docs updates in `mise.toml`, `AGENTS.md`, and `ops/bmad/github-cli-reliability.md`
- scaffold `_bmad_output/issue-146-execution.md`

## Verification
- `mise run smoketest:bmad-repo-health-retry`
- `python3 -m py_compile cli/bb.py`

Closes #146
