### PR TITLE
feat: add retry-aware read-only gh status helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run bmad:closeout-loop -- <pr> [--primary-repo <path>]` | unified closeout summary (merge+cleanup+drift evidence, JSON; defaults `PRIMARY_REPO` env then cwd) |
 | `mise run bmad:closeout-loop:artifact -- <pr> [--primary-repo <path>]` | same as closeout-loop, plus timestamped artifact write to `_bmad_output/evidence/closeout/` |
 | `mise run bmad:closeout-cleanup-summary -- [--evidence-dir <dir>] [--limit <n>]` | read-only summary of closeout artifact cleanup status fields for quick operator review (defaults to `_bmad_output/evidence/closeout`) |
+| `mise run bmad:gh-readonly-status -- issue-view <id> \| pr-view <id>` | read-only JSON status helper with bounded retry for transient `gh` API connectivity errors |
 | `mise run bmad:retrigger-pr-checks -- <pr> [--workflow ci.yml] [--dry-run]` | dispatch CI workflow for PR head branch without no-op commit retriggers |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
@@ -71,7 +72,8 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-closeout-cleanup-summary` | local validation for closeout cleanup summary helper JSON output contract |
 | `mise run smoketest:bmad-closeout-artifact-summary` | local validation for closeout artifact write path + summary visibility contract |
 | `mise run smoketest:bmad-repo-health-retry` | local validation for bounded transient retry behavior in `cli/bb.py repo-health` gh read paths |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry, fail-fast) |
+| `mise run smoketest:bmad-gh-readonly-status` | local validation for bounded transient retry behavior in read-only issue/pr status helper |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline

--- a/_bmad_output/issue-148-execution.md
+++ b/_bmad_output/issue-148-execution.md
@@ -1,0 +1,26 @@
+# Issue 148 — execution closeout
+
+## Ticket
+- Issue: #148
+- Title: Extend bounded gh retry coverage beyond repo-health status paths
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added read-only status helper `ops/bmad/gh_readonly_status.py` with bounded retry for transient `gh` API connectivity failures.
+- Helper supports JSON-first status calls for `issue-view` and `pr-view`.
+- Added deterministic smoke test `ops/smoketest/smoketest-bmad-gh-readonly-status.sh` and task/docs wiring in `mise.toml`, `AGENTS.md`, and `ops/bmad/github-cli-reliability.md`.
+
+## Out of scope
+- Retry policy expansion to mutating GitHub operations.
+
+## Verification evidence
+- `mise run smoketest:bmad-gh-readonly-status` → `PASS`
+- `mise run bmad:gh-readonly-status -- issue-view 148` → `ok: true`, `attempts: 1`, JSON payload returned
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/148
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Retry behavior mirrors repo-health policy (3 attempts, short backoff, transient-signature gated).

--- a/mise.toml
+++ b/mise.toml
@@ -84,6 +84,10 @@ run = "bash ops/bmad/closeout_loop_artifact.sh"
 description = "Read-only summary of closeout artifact cleanup status fields"
 run = "python3 ops/bmad/closeout_cleanup_summary.py"
 
+[tasks."bmad:gh-readonly-status"]
+description = "Read-only issue/pr status helper with bounded retry for transient gh connectivity failures"
+run = "python3 ops/bmad/gh_readonly_status.py"
+
 [tasks."bmad:retrigger-pr-checks"]
 description = "Dispatch CI workflow for a PR head branch (no empty commit retrigger)"
 run = "python3 ops/bmad/retrigger_pr_checks.py"
@@ -156,9 +160,13 @@ run = "bash ops/smoketest/smoketest-bmad-closeout-artifact-summary.sh"
 description = "Local smoke test for repo-health transient gh retry behavior"
 run = "bash ops/smoketest/smoketest-bmad-repo-health-retry.sh"
 
+[tasks."smoketest:bmad-gh-readonly-status"]
+description = "Local smoke test for read-only gh status helper retry behavior"
+run = "bash ops/smoketest/smoketest-bmad-gh-readonly-status.sh"
+
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/gh_readonly_status.py
+++ b/ops/bmad/gh_readonly_status.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Read-only GitHub status helper with bounded retry for transient API failures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def _is_transient(err: str) -> bool:
+    err_l = err.lower()
+    return (
+        "error connecting to api.github.com" in err_l
+        or "connection reset" in err_l
+        or "timed out" in err_l
+    )
+
+
+def _run_once(argv: list[str]) -> tuple[int, str, str]:
+    proc = subprocess.run(argv, text=True, capture_output=True, check=False)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def run_with_retry(argv: list[str], attempts: int = 3) -> tuple[int, str, str, int]:
+    rc, out, err = 1, "", ""
+    for attempt in range(1, attempts + 1):
+        rc, out, err = _run_once(argv)
+        if rc == 0:
+            return rc, out, err, attempt
+        if attempt == attempts or not _is_transient(err):
+            return rc, out, err, attempt
+        time.sleep(0.5 * attempt)
+    return rc, out, err, attempts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Read-only gh status helper with bounded retries")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_issue = sub.add_parser("issue-view", help="Fetch issue status JSON with retry")
+    p_issue.add_argument("issue")
+
+    p_pr = sub.add_parser("pr-view", help="Fetch PR status JSON with retry")
+    p_pr.add_argument("pr")
+
+    args = parser.parse_args()
+
+    if args.command == "issue-view":
+        cmd = ["gh", "issue", "view", str(args.issue), "--json", "number,title,state,url,updatedAt"]
+    else:
+        cmd = [
+            "gh",
+            "pr",
+            "view",
+            str(args.pr),
+            "--json",
+            "number,title,state,url,headRefName,mergeStateStatus,statusCheckRollup,updatedAt",
+        ]
+
+    rc, out, err, attempts = run_with_retry(cmd)
+    payload: dict[str, Any] = {
+        "ok": rc == 0,
+        "attempts": attempts,
+        "command": args.command,
+        "stderr": err,
+        "data": None,
+    }
+
+    if rc == 0 and out:
+        try:
+            payload["data"] = json.loads(out)
+        except json.JSONDecodeError:
+            payload["ok"] = False
+            payload["stderr"] = "invalid JSON from gh command"
+            print(json.dumps(payload, indent=2))
+            return 1
+
+    print(json.dumps(payload, indent=2))
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/bmad/github-cli-reliability.md
+++ b/ops/bmad/github-cli-reliability.md
@@ -45,10 +45,18 @@ For read-only repo snapshots, `cli/bb.py repo-health` now applies bounded retry 
 
 Use `mise run repo-health` / `mise run repo-health:artifact` as the preferred status path in automation loops.
 
-Local regression check:
+For direct issue/PR status reads in automation loops, use the retry-aware helper:
+
+```bash
+mise run bmad:gh-readonly-status -- issue-view <id>
+mise run bmad:gh-readonly-status -- pr-view <id>
+```
+
+Local regression checks:
 
 ```bash
 mise run smoketest:bmad-repo-health-retry
+mise run smoketest:bmad-gh-readonly-status
 ```
 
 ## Operational checklist

--- a/ops/smoketest/smoketest-bmad-gh-readonly-status.sh
+++ b/ops/smoketest/smoketest-bmad-gh-readonly-status.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Smoke test for ops/bmad/gh_readonly_status.py retry semantics.
+
+set -euo pipefail
+
+BLOODBANK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${BLOODBANK_ROOT}"
+
+python3 - <<'PY'
+import ops.bmad.gh_readonly_status as s
+
+orig_run_once = s._run_once
+orig_sleep = s.time.sleep
+
+try:
+    # transient -> success on retry
+    attempts = []
+    sleeps = []
+    responses = [
+        (1, "", "error connecting to api.github.com"),
+        (1, "", "timed out"),
+        (0, '{"state":"OPEN"}', ""),
+    ]
+
+    def fake_once(_argv):
+        attempts.append(1)
+        return responses.pop(0)
+
+    s._run_once = fake_once
+    s.time.sleep = lambda sec: sleeps.append(sec)
+    rc, out, err, tries = s.run_with_retry(["gh", "issue", "view", "1"])
+    assert rc == 0 and tries == 3 and 'OPEN' in out and err == "", (rc, out, err, tries)
+    assert sleeps == [0.5, 1.0], sleeps
+
+    # non-transient should not retry
+    attempts = []
+    sleeps = []
+
+    def fake_non(_argv):
+        attempts.append(1)
+        return (1, "", "GraphQL: Projects (classic) is being deprecated")
+
+    s._run_once = fake_non
+    s.time.sleep = lambda sec: sleeps.append(sec)
+    rc, out, err, tries = s.run_with_retry(["gh", "pr", "view", "2"])
+    assert rc == 1 and tries == 1 and "deprecated" in err.lower(), (rc, out, err, tries)
+    assert sleeps == [], sleeps
+
+finally:
+    s._run_once = orig_run_once
+    s.time.sleep = orig_sleep
+PY
+
+echo "smoketest-bmad-gh-readonly-status: PASS"


### PR DESCRIPTION
## Summary
- add read-only retry-aware status helper `ops/bmad/gh_readonly_status.py` for `issue-view` and `pr-view`
- apply bounded transient retry policy (3 attempts + short backoff, transient-signature gated)
- add deterministic smoke coverage `smoketest-bmad-gh-readonly-status`
- wire task/docs updates in `mise.toml`, `AGENTS.md`, and `ops/bmad/github-cli-reliability.md`
- scaffold `_bmad_output/issue-148-execution.md`

## Verification
- `mise run smoketest:bmad-gh-readonly-status`
- `python3 -m py_compile ops/bmad/gh_readonly_status.py`
- `mise run bmad:gh-readonly-status -- issue-view 148`

Closes #148
