### PR TITLE
refactor: adopt retry-aware gh readonly helper in BMAD scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ alongside each service, using Holyfields-generated publishers.
 - For shell-safe issue/PR markdown composition, use `ops/bmad/github-body-authoring.md` and prefer `--body-file`/file-backed REST payloads over inline `--body "..."`.
 - For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
 - `repo-health` applies bounded retries for transient GitHub API connectivity errors on read-only `gh` status calls (`issue list`, `pr list`, `pr checks`).
+- For direct automation reads of issue/PR state, prefer `mise run bmad:gh-readonly-status -- issue-view <id>|pr-view <id>` over raw `gh ... view`.
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.

--- a/_bmad_output/issue-150-execution.md
+++ b/_bmad_output/issue-150-execution.md
@@ -1,0 +1,29 @@
+# Issue 150 — execution closeout
+
+## Ticket
+- Issue: #150
+- Title: Adopt retry-aware gh readonly helper across BMAD automation paths
+- Owner: hermes (pilot)
+
+## Scope completed
+- Updated `ops/bmad/merge_pr_safe.py` to use `ops/bmad/gh_readonly_status.py pr-view` for merged-state verification reads.
+- Updated `ops/bmad/retrigger_pr_checks.py` to resolve `repo-view` and `pr-view` through `gh_readonly_status.py` instead of raw direct `gh ... view` calls.
+- Extended `ops/bmad/gh_readonly_status.py` with `repo-view` support and `mergedAt` in `pr-view` payload.
+- Added migration guidance and intentional raw-`gh` mutation exceptions in `ops/bmad/github-cli-reliability.md` and updated operator guidance in `AGENTS.md`.
+
+## Out of scope
+- Mutating command retry adoption (intentionally excluded).
+
+## Verification evidence
+- `mise run smoketest:bmad-merge-pr-safe` → `PASS`
+- `mise run smoketest:bmad-retrigger-pr-checks` → `PASS`
+- `mise run smoketest:bmad-gh-readonly-status` → `PASS`
+- `python3 -m py_compile ops/bmad/merge_pr_safe.py ops/bmad/retrigger_pr_checks.py ops/bmad/gh_readonly_status.py` → success
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/150
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Read-only `gh` adoption is now centralized for operator scripts that query issue/PR/repo metadata.

--- a/ops/bmad/gh_readonly_status.py
+++ b/ops/bmad/gh_readonly_status.py
@@ -47,19 +47,23 @@ def main() -> int:
     p_pr = sub.add_parser("pr-view", help="Fetch PR status JSON with retry")
     p_pr.add_argument("pr")
 
+    sub.add_parser("repo-view", help="Fetch repo metadata JSON with retry")
+
     args = parser.parse_args()
 
     if args.command == "issue-view":
         cmd = ["gh", "issue", "view", str(args.issue), "--json", "number,title,state,url,updatedAt"]
-    else:
+    elif args.command == "pr-view":
         cmd = [
             "gh",
             "pr",
             "view",
             str(args.pr),
             "--json",
-            "number,title,state,url,headRefName,mergeStateStatus,statusCheckRollup,updatedAt",
+            "number,title,state,url,headRefName,mergeStateStatus,statusCheckRollup,mergedAt,updatedAt",
         ]
+    else:
+        cmd = ["gh", "repo", "view", "--json", "nameWithOwner"]
 
     rc, out, err, attempts = run_with_retry(cmd)
     payload: dict[str, Any] = {

--- a/ops/bmad/github-cli-reliability.md
+++ b/ops/bmad/github-cli-reliability.md
@@ -59,6 +59,17 @@ mise run smoketest:bmad-repo-health-retry
 mise run smoketest:bmad-gh-readonly-status
 ```
 
+## Intentional raw-`gh` exceptions (currently)
+
+The retry helper is intentionally **not** used for mutating operations:
+
+- `gh pr merge ...`
+- `gh issue create ...`
+- `gh pr create ...`
+- `gh api -X POST ...` dispatch/mutation calls
+
+Those paths should surface failures immediately to avoid accidental duplicate writes.
+
 ## Operational checklist
 
 1. Capture failing `gh` command + stderr in the ticket evidence.

--- a/ops/bmad/merge_pr_safe.py
+++ b/ops/bmad/merge_pr_safe.py
@@ -13,6 +13,7 @@ import json
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 
 @dataclass
@@ -28,13 +29,32 @@ def run(*args: str) -> CmdResult:
 
 
 def gh_pr_view(pr: str) -> dict[str, object]:
+    helper = Path(__file__).with_name("gh_readonly_status.py")
     cp = subprocess.run(
-        ["gh", "pr", "view", pr, "--json", "number,state,mergedAt,url,headRefName"],
-        check=True,
+        [sys.executable, str(helper), "pr-view", pr],
         text=True,
         capture_output=True,
+        check=False,
     )
-    return json.loads(cp.stdout)
+    if cp.returncode != 0:
+        raise RuntimeError(cp.stderr.strip() or cp.stdout.strip() or "gh pr view failed")
+
+    try:
+        payload = json.loads(cp.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("invalid JSON from gh_readonly_status pr-view") from exc
+
+    data = payload.get("data")
+    if not payload.get("ok") or not isinstance(data, dict):
+        raise RuntimeError(str(payload.get("stderr") or "gh_readonly_status returned no data"))
+
+    return {
+        "number": data.get("number"),
+        "state": data.get("state"),
+        "mergedAt": data.get("mergedAt"),
+        "url": data.get("url"),
+        "headRefName": data.get("headRefName"),
+    }
 
 
 def branch_exists_local(branch: str) -> bool:
@@ -78,8 +98,8 @@ def main() -> int:
 
     try:
         view = gh_pr_view(args.pr)
-    except subprocess.CalledProcessError as exc:
-        print(f"pr_view_error: {exc.stderr.strip() or exc}", file=sys.stderr)
+    except RuntimeError as exc:
+        print(f"pr_view_error: {exc}", file=sys.stderr)
         if merge.out:
             print(merge.out)
         if merge.err:

--- a/ops/bmad/retrigger_pr_checks.py
+++ b/ops/bmad/retrigger_pr_checks.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
 
@@ -26,6 +27,28 @@ def run_json(cmd: list[str]) -> Any:
         return json.loads(result.stdout)
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"invalid JSON output from command: {' '.join(cmd)}") from exc
+
+
+def run_json_readonly_with_retry(kind: str, value: str | None = None) -> Any:
+    helper = Path(__file__).with_name("gh_readonly_status.py")
+    cmd = [sys.executable, str(helper), kind]
+    if value is not None:
+        cmd.append(value)
+    result = run(cmd)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "command failed")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid JSON output from command: {' '.join(cmd)}") from exc
+
+    if not payload.get("ok"):
+        raise RuntimeError(str(payload.get("stderr") or "helper command failed"))
+
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise RuntimeError("helper returned no data")
+    return data
 
 
 def main() -> int:
@@ -45,17 +68,8 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    repo = run_json(["gh", "repo", "view", "--json", "nameWithOwner"])["nameWithOwner"]
-    pr = run_json(
-        [
-            "gh",
-            "pr",
-            "view",
-            str(args.pr),
-            "--json",
-            "number,state,headRefName,url",
-        ]
-    )
+    repo = run_json_readonly_with_retry("repo-view")["nameWithOwner"]
+    pr = run_json_readonly_with_retry("pr-view", str(args.pr))
 
     payload: dict[str, Any] = {
         "repository": repo,


### PR DESCRIPTION
## Summary
- route read-only PR verification in `merge_pr_safe.py` through retry helper (`gh_readonly_status.py pr-view`)
- route read-only repo/PR lookups in `retrigger_pr_checks.py` through retry helper (`repo-view`, `pr-view`)
- extend helper with `repo-view` and include `mergedAt` in `pr-view` payload
- document migration + intentional raw-`gh` mutation exceptions
- add issue execution closeout scaffold for #150

## Verification
- `mise run smoketest:bmad-merge-pr-safe`
- `mise run smoketest:bmad-retrigger-pr-checks`
- `mise run smoketest:bmad-gh-readonly-status`
- `python3 -m py_compile ops/bmad/merge_pr_safe.py ops/bmad/retrigger_pr_checks.py ops/bmad/gh_readonly_status.py`

Closes #150
