### PR TITLE
test: add repo-view contract smoke coverage

### DIFF
--- a/_bmad_output/issue-152-execution.md
+++ b/_bmad_output/issue-152-execution.md
@@ -1,0 +1,25 @@
+# Issue 152 — execution closeout
+
+## Ticket
+- Issue: #152
+- Title: Add explicit smoke coverage for gh_readonly_status repo-view contract
+- Owner: hermes (pilot)
+
+## Scope completed
+- Extended `ops/smoketest/smoketest-bmad-gh-readonly-status.sh` to explicitly validate the `repo-view` command contract in `ops/bmad/gh_readonly_status.py` using stdlib-only mocking.
+- Added assertions for invoked GH argv (`gh repo view --json nameWithOwner`) and output payload contract (`ok=true`, `command=repo-view`, `data.nameWithOwner` present).
+
+## Out of scope
+- Live network integration tests against GitHub API.
+
+## Verification evidence
+- `mise run smoketest:bmad-gh-readonly-status` → `PASS`
+- `python3 -m py_compile ops/bmad/gh_readonly_status.py` → success
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/152
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Test remains deterministic and offline; no change to production helper behavior.

--- a/ops/smoketest/smoketest-bmad-gh-readonly-status.sh
+++ b/ops/smoketest/smoketest-bmad-gh-readonly-status.sh
@@ -7,10 +7,16 @@ BLOODBANK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${BLOODBANK_ROOT}"
 
 python3 - <<'PY'
+import contextlib
+import io
+import json
+import sys
+
 import ops.bmad.gh_readonly_status as s
 
 orig_run_once = s._run_once
 orig_sleep = s.time.sleep
+orig_argv = sys.argv[:]
 
 try:
     # transient -> success on retry
@@ -46,9 +52,31 @@ try:
     assert rc == 1 and tries == 1 and "deprecated" in err.lower(), (rc, out, err, tries)
     assert sleeps == [], sleeps
 
+    # repo-view command contract (no network; mocked gh response)
+    observed = []
+
+    def fake_repo(argv):
+        observed.append(argv)
+        return (0, '{"nameWithOwner":"delorenj/bloodbank"}', "")
+
+    s._run_once = fake_repo
+    s.time.sleep = lambda _sec: None
+    sys.argv = ["gh_readonly_status.py", "repo-view"]
+    stream = io.StringIO()
+    with contextlib.redirect_stdout(stream):
+        exit_code = s.main()
+    payload = json.loads(stream.getvalue())
+
+    assert exit_code == 0, exit_code
+    assert observed == [["gh", "repo", "view", "--json", "nameWithOwner"]], observed
+    assert payload["ok"] is True, payload
+    assert payload["command"] == "repo-view", payload
+    assert payload["data"]["nameWithOwner"] == "delorenj/bloodbank", payload
+
 finally:
     s._run_once = orig_run_once
     s.time.sleep = orig_sleep
+    sys.argv = orig_argv
 PY
 
 echo "smoketest-bmad-gh-readonly-status: PASS"


### PR DESCRIPTION
## Summary
- extend `smoketest-bmad-gh-readonly-status` to explicitly validate `repo-view` command contract
- keep test fully deterministic/offline via stdlib-only mocking
- assert invoked command argv and payload shape (`ok`, `command`, `data.nameWithOwner`)
- include BMAD closeout artifact for #152

## Verification
- `mise run smoketest:bmad-gh-readonly-status`
- `python3 -m py_compile ops/bmad/gh_readonly_status.py`

Closes #152
