### PR TITLE
test: add issue/pr view contract smoke coverage

### DIFF
--- a/_bmad_output/issue-154-execution.md
+++ b/_bmad_output/issue-154-execution.md
@@ -1,0 +1,25 @@
+# Issue 154 — execution closeout
+
+## Ticket
+- Issue: #154
+- Title: Add explicit command-contract smoke coverage for gh_readonly_status issue/pr views
+- Owner: hermes (pilot)
+
+## Scope completed
+- Extended `ops/smoketest/smoketest-bmad-gh-readonly-status.sh` to validate `issue-view` and `pr-view` command contracts through `gh_readonly_status.main()` with mocked `_run_once` responses.
+- Added assertions for expected GH argv construction and required payload keys (`ok`, `command`, selected `data` fields) for both commands.
+
+## Out of scope
+- Live network integration checks against GitHub API.
+
+## Verification evidence
+- `mise run smoketest:bmad-gh-readonly-status` → `PASS`
+- `python3 -m py_compile ops/bmad/gh_readonly_status.py` → success
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/154
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Coverage remains deterministic and offline (stdlib-only mocking).

--- a/ops/smoketest/smoketest-bmad-gh-readonly-status.sh
+++ b/ops/smoketest/smoketest-bmad-gh-readonly-status.sh
@@ -52,21 +52,55 @@ try:
     assert rc == 1 and tries == 1 and "deprecated" in err.lower(), (rc, out, err, tries)
     assert sleeps == [], sleeps
 
+    def run_main_case(argv, mocked_response):
+        observed = []
+
+        def fake_cmd(cmd_argv):
+            observed.append(cmd_argv)
+            return mocked_response
+
+        s._run_once = fake_cmd
+        s.time.sleep = lambda _sec: None
+        sys.argv = argv
+        stream = io.StringIO()
+        with contextlib.redirect_stdout(stream):
+            exit_code = s.main()
+        payload = json.loads(stream.getvalue())
+        return exit_code, payload, observed
+
+    # issue-view command contract (no network; mocked gh response)
+    exit_code, payload, observed = run_main_case(
+        ["gh_readonly_status.py", "issue-view", "154"],
+        (0, '{"number":154,"title":"T","state":"OPEN","url":"u","updatedAt":"now"}', ""),
+    )
+    assert exit_code == 0, exit_code
+    assert observed == [["gh", "issue", "view", "154", "--json", "number,title,state,url,updatedAt"]], observed
+    assert payload["ok"] is True, payload
+    assert payload["command"] == "issue-view", payload
+    assert payload["data"]["number"] == 154, payload
+    assert payload["data"]["state"] == "OPEN", payload
+
+    # pr-view command contract (no network; mocked gh response)
+    exit_code, payload, observed = run_main_case(
+        ["gh_readonly_status.py", "pr-view", "151"],
+        (
+            0,
+            '{"number":151,"title":"P","state":"OPEN","url":"u","headRefName":"h","mergeStateStatus":"CLEAN","statusCheckRollup":[],"mergedAt":null,"updatedAt":"now"}',
+            "",
+        ),
+    )
+    assert exit_code == 0, exit_code
+    assert observed == [["gh", "pr", "view", "151", "--json", "number,title,state,url,headRefName,mergeStateStatus,statusCheckRollup,mergedAt,updatedAt"]], observed
+    assert payload["ok"] is True, payload
+    assert payload["command"] == "pr-view", payload
+    assert payload["data"]["number"] == 151, payload
+    assert payload["data"]["headRefName"] == "h", payload
+
     # repo-view command contract (no network; mocked gh response)
-    observed = []
-
-    def fake_repo(argv):
-        observed.append(argv)
-        return (0, '{"nameWithOwner":"delorenj/bloodbank"}', "")
-
-    s._run_once = fake_repo
-    s.time.sleep = lambda _sec: None
-    sys.argv = ["gh_readonly_status.py", "repo-view"]
-    stream = io.StringIO()
-    with contextlib.redirect_stdout(stream):
-        exit_code = s.main()
-    payload = json.loads(stream.getvalue())
-
+    exit_code, payload, observed = run_main_case(
+        ["gh_readonly_status.py", "repo-view"],
+        (0, '{"nameWithOwner":"delorenj/bloodbank"}', ""),
+    )
     assert exit_code == 0, exit_code
     assert observed == [["gh", "repo", "view", "--json", "nameWithOwner"]], observed
     assert payload["ok"] is True, payload


### PR DESCRIPTION
## Summary
- extend `smoketest-bmad-gh-readonly-status` with explicit `issue-view` and `pr-view` command-contract checks via `gh_readonly_status.main()`
- assert expected gh argv generation and payload contract fields for both commands
- keep tests deterministic/offline using stdlib-only mocked `_run_once`
- include BMAD closeout artifact for #154

## Verification
- `mise run smoketest:bmad-gh-readonly-status`
- `python3 -m py_compile ops/bmad/gh_readonly_status.py`

Closes #154
