### PR TITLE
chore: harden Hermes runtime artifact hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ _bmad_output/evidence/closeout/*.json
 
 # Local OpenClaw hook workspace artifacts (operator-local; not project source)
 /services/agent-hooks/openclaw/
+
+# Repo-local Hermes runtime state (secrets/sessions/logs)
+agents/hermes/runtime/**
+!agents/hermes/runtime/.gitignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,8 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-closeout-artifact-summary` | local validation for closeout artifact write path + summary visibility contract |
 | `mise run smoketest:bmad-repo-health-retry` | local validation for bounded transient retry behavior in `cli/bb.py repo-health` gh read paths |
 | `mise run smoketest:bmad-gh-readonly-status` | local validation for bounded transient retry behavior in read-only issue/pr status helper |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status, fail-fast) |
+| `mise run smoketest:hermes-runtime-hygiene` | local validation for Hermes runtime ignore contract (runtime state ignored, skeleton trackable) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status/hermes-runtime-hygiene, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline
@@ -100,6 +101,7 @@ alongside each service, using Holyfields-generated publishers.
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.
 - If primary checkout is dirty/behind, use the dedicated clean-worktree automation path in `ops/bmad/clean-worktree-automation.md` (do not stash/discard unknown local changes).
 - Local OpenClaw hook scratch path (`services/agent-hooks/openclaw/`) is intentionally treated as operator-local and excluded from repo tracking.
+- Hermes runtime state under `agents/hermes/runtime/` is operator-local; only skeleton docs/launch scripts + `runtime/.gitignore` should be tracked.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.
 
 ## Conventions

--- a/_bmad_output/issue-156-execution.md
+++ b/_bmad_output/issue-156-execution.md
@@ -1,0 +1,26 @@
+# Issue 156 — execution closeout
+
+## Ticket
+- Issue: #156
+- Title: Harden Hermes runtime artifact hygiene (ignore + clean skeleton + secret-safe defaults)
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added/committed repo-local Hermes skeleton under `agents/` (docs + launcher/provision scripts + `runtime/.gitignore`) while keeping runtime secrets/session state excluded.
+- Promoted runtime ignore rule in root `.gitignore` for `agents/hermes/runtime/**` with explicit allowlist for `runtime/.gitignore`.
+- Added deterministic local smoke test `ops/smoketest/smoketest-hermes-runtime-hygiene.sh` and wired it into `mise.toml` + `AGENTS.md` task docs.
+
+## Out of scope
+- Rotation/migration of any existing local runtime secrets.
+
+## Verification evidence
+- `mise run smoketest:hermes-runtime-hygiene` → `PASS`
+- `git status --short --ignored agents/hermes/runtime` → runtime secret/state files ignored (`!!`) under `agents/hermes/runtime`
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/156
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- `agents/hermes/runtime/` remains operator-local at runtime; only `.gitignore` is tracked there.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,9 @@
+# Bloodbank Agents
+
+Repository-local autonomous agents live here.
+
+## Layout
+- `hermes/` — repository-scoped Hermes PM/ingress agent runtime for Bloodbank.
+
+## Rule
+Each deployed agent for this repository must live inside this repository and remain independently operable.

--- a/agents/hermes/README.md
+++ b/agents/hermes/README.md
@@ -1,0 +1,37 @@
+# Hermes (Bloodbank)
+
+Hermes is the repository-scoped PM/ingress agent for Bloodbank.
+
+## Provisioning status
+✅ Provisioned as a repo-local runtime.
+
+Runtime home:
+- `agents/hermes/runtime` (scoped via `HERMES_HOME`)
+
+Launcher:
+- `agents/hermes/bin/hermes-bloodbank`
+
+Provision script:
+- `agents/hermes/provision.sh`
+
+## Contract
+- Consumes Bloodbank events relevant to this repository.
+- Produces Bloodbank events as outputs/decisions/artifacts.
+- Operates independently from Hermes instances assigned to other repositories.
+
+## Initial subject lane (proposed)
+- `agent.hermes.bloodbank.#` for Hermes-directed command/event routing.
+
+## Usage
+From repo root:
+
+```bash
+./agents/hermes/provision.sh
+./agents/hermes/bin/hermes-bloodbank status
+./agents/hermes/bin/hermes-bloodbank chat
+```
+
+## Notes
+- Runtime scaffolding lives inside this repo (`agents/hermes/`) so deployment is repo-local.
+- `runtime/` state is intentionally git-ignored (sessions/logs/auth/secrets).
+- Planned future enhancement: emit artifact creation events when docs are created (not implemented yet).

--- a/agents/hermes/bin/hermes-bloodbank
+++ b/agents/hermes/bin/hermes-bloodbank
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AGENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HERMES_HOME="${AGENT_DIR}/runtime"
+HERMES_BIN="${HERMES_BIN:-/home/delorenj/code/hermes-agent/.venv/bin/hermes}"
+
+if [[ ! -x "$HERMES_BIN" ]]; then
+  echo "Hermes binary not found/executable at: $HERMES_BIN" >&2
+  echo "Set HERMES_BIN to your hermes executable path and retry." >&2
+  exit 1
+fi
+
+exec env HERMES_HOME="$HERMES_HOME" "$HERMES_BIN" "$@"

--- a/agents/hermes/provision.sh
+++ b/agents/hermes/provision.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HERMES_HOME="${REPO_ROOT}/agents/hermes/runtime"
+HERMES_BIN="${HERMES_BIN:-/home/delorenj/code/hermes-agent/.venv/bin/hermes}"
+
+mkdir -p "$HERMES_HOME"
+
+# Bootstrap Hermes home/state if missing
+env HERMES_HOME="$HERMES_HOME" "$HERMES_BIN" status >/dev/null
+
+# Repo-scoped defaults for Bloodbank Hermes
+env HERMES_HOME="$HERMES_HOME" "$HERMES_BIN" config set terminal.cwd "$REPO_ROOT"
+env HERMES_HOME="$HERMES_HOME" "$HERMES_BIN" config set model.default qwen3.6
+env HERMES_HOME="$HERMES_HOME" "$HERMES_BIN" config set model.provider ollama-launch
+
+echo "Provisioned Hermes runtime at: $HERMES_HOME"
+env HERMES_HOME="$HERMES_HOME" "$HERMES_BIN" doctor

--- a/agents/hermes/runtime/.gitignore
+++ b/agents/hermes/runtime/.gitignore
@@ -1,0 +1,3 @@
+# Runtime state only; keep this directory but do not commit state.
+*
+!.gitignore

--- a/mise.toml
+++ b/mise.toml
@@ -164,9 +164,13 @@ run = "bash ops/smoketest/smoketest-bmad-repo-health-retry.sh"
 description = "Local smoke test for read-only gh status helper retry behavior"
 run = "bash ops/smoketest/smoketest-bmad-gh-readonly-status.sh"
 
+[tasks."smoketest:hermes-runtime-hygiene"]
+description = "Local smoke test for Hermes runtime ignore/track contract"
+run = "bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh"
+
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:hermes-runtime-hygiene"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/smoketest/smoketest-hermes-runtime-hygiene.sh
+++ b/ops/smoketest/smoketest-hermes-runtime-hygiene.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Verify Hermes runtime hygiene: runtime state ignored, skeleton tracked.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+ignored=(
+  "agents/hermes/runtime/.env"
+  "agents/hermes/runtime/auth.json"
+  "agents/hermes/runtime/auth.lock"
+  "agents/hermes/runtime/config.yaml"
+  "agents/hermes/runtime/logs/session.log"
+)
+
+for p in "${ignored[@]}"; do
+  if ! git check-ignore -q "$p"; then
+    echo "expected ignored path not ignored: $p" >&2
+    exit 1
+  fi
+done
+
+if git check-ignore -q "agents/hermes/runtime/.gitignore"; then
+  echo "runtime/.gitignore must remain trackable" >&2
+  exit 1
+fi
+
+if git check-ignore -q "agents/hermes/README.md"; then
+  echo "agents/hermes/README.md should be tracked, not ignored" >&2
+  exit 1
+fi
+
+echo "smoketest-hermes-runtime-hygiene: PASS"


### PR DESCRIPTION
## Summary
- add/track repo-local Hermes skeleton under `agents/` (docs + launcher/provision + `runtime/.gitignore`)
- harden root ignore rules for `agents/hermes/runtime/**` with explicit `.gitignore` allowlist
- add deterministic runtime hygiene smoke test (`smoketest:hermes-runtime-hygiene`)
- wire smoke task into `mise.toml` and `AGENTS.md`
- include BMAD closeout artifact for #156

## Verification
- `mise run smoketest:hermes-runtime-hygiene`
- `git status --short --ignored agents/hermes/runtime`

Closes #156
