### PR TITLE
docs: include repo-view in gh-readonly-status contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run bmad:closeout-loop -- <pr> [--primary-repo <path>]` | unified closeout summary (merge+cleanup+drift evidence, JSON; defaults `PRIMARY_REPO` env then cwd) |
 | `mise run bmad:closeout-loop:artifact -- <pr> [--primary-repo <path>]` | same as closeout-loop, plus timestamped artifact write to `_bmad_output/evidence/closeout/` |
 | `mise run bmad:closeout-cleanup-summary -- [--evidence-dir <dir>] [--limit <n>]` | read-only summary of closeout artifact cleanup status fields for quick operator review (defaults to `_bmad_output/evidence/closeout`) |
-| `mise run bmad:gh-readonly-status -- issue-view <id> \| pr-view <id>` | read-only JSON status helper with bounded retry for transient `gh` API connectivity errors |
+| `mise run bmad:gh-readonly-status -- issue-view <id> \| pr-view <id> \| repo-view` | read-only JSON status helper with bounded retry for transient `gh` API connectivity errors |
 | `mise run bmad:retrigger-pr-checks -- <pr> [--workflow ci.yml] [--dry-run]` | dispatch CI workflow for PR head branch without no-op commit retriggers |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
@@ -94,7 +94,7 @@ alongside each service, using Holyfields-generated publishers.
 - For shell-safe issue/PR markdown composition, use `ops/bmad/github-body-authoring.md` and prefer `--body-file`/file-backed REST payloads over inline `--body "..."`.
 - For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
 - `repo-health` applies bounded retries for transient GitHub API connectivity errors on read-only `gh` status calls (`issue list`, `pr list`, `pr checks`).
-- For direct automation reads of issue/PR state, prefer `mise run bmad:gh-readonly-status -- issue-view <id>|pr-view <id>` over raw `gh ... view`.
+- For direct automation reads of issue/PR/repo state, prefer `mise run bmad:gh-readonly-status -- issue-view <id>|pr-view <id>|repo-view` over raw `gh ... view`.
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.

--- a/_bmad_output/issue-158-execution.md
+++ b/_bmad_output/issue-158-execution.md
@@ -1,0 +1,26 @@
+# Issue 158 — execution closeout
+
+## Ticket
+- Issue: #158
+- Title: Document full gh_readonly_status command surface (include repo-view)
+- Owner: hermes (pilot)
+
+## Scope completed
+- Updated `AGENTS.md` task table + operator guidance to include full helper surface: `issue-view`, `pr-view`, and `repo-view`.
+- Updated `mise.toml` task description for `bmad:gh-readonly-status` to reflect issue/pr/repo support.
+- Updated `ops/bmad/github-cli-reliability.md` examples to include `repo-view`.
+
+## Out of scope
+- Runtime behavior changes to `gh_readonly_status.py`.
+
+## Verification evidence
+- `mise run bmad:gh-readonly-status -- repo-view` → `ok: true` with `nameWithOwner` payload.
+- `rg -n "repo-view|issue/pr/repo" AGENTS.md mise.toml ops/bmad/github-cli-reliability.md` → updated command surface confirmed.
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/158
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- This is doc/task-contract alignment only; no functional code-path change.

--- a/mise.toml
+++ b/mise.toml
@@ -85,7 +85,7 @@ description = "Read-only summary of closeout artifact cleanup status fields"
 run = "python3 ops/bmad/closeout_cleanup_summary.py"
 
 [tasks."bmad:gh-readonly-status"]
-description = "Read-only issue/pr status helper with bounded retry for transient gh connectivity failures"
+description = "Read-only issue/pr/repo status helper with bounded retry for transient gh connectivity failures"
 run = "python3 ops/bmad/gh_readonly_status.py"
 
 [tasks."bmad:retrigger-pr-checks"]

--- a/ops/bmad/github-cli-reliability.md
+++ b/ops/bmad/github-cli-reliability.md
@@ -45,11 +45,12 @@ For read-only repo snapshots, `cli/bb.py repo-health` now applies bounded retry 
 
 Use `mise run repo-health` / `mise run repo-health:artifact` as the preferred status path in automation loops.
 
-For direct issue/PR status reads in automation loops, use the retry-aware helper:
+For direct issue/PR/repo status reads in automation loops, use the retry-aware helper:
 
 ```bash
 mise run bmad:gh-readonly-status -- issue-view <id>
 mise run bmad:gh-readonly-status -- pr-view <id>
+mise run bmad:gh-readonly-status -- repo-view
 ```
 
 Local regression checks:


### PR DESCRIPTION
## Summary
- align docs/task contracts with actual `gh_readonly_status` command surface
- include `repo-view` alongside `issue-view`/`pr-view` in:
  - `AGENTS.md`
  - `mise.toml` task description for `bmad:gh-readonly-status`
  - `ops/bmad/github-cli-reliability.md` examples
- add BMAD closeout artifact for #158

## Verification
- `mise run bmad:gh-readonly-status -- repo-view`
- `rg -n "repo-view|issue/pr/repo" AGENTS.md mise.toml ops/bmad/github-cli-reliability.md`

Closes #158
