### PR TITLE
feat: add strict-clean preflight helper for BMAD loops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run bmad:closeout-cleanup-summary -- [--evidence-dir <dir>] [--limit <n>]` | read-only summary of closeout artifact cleanup status fields for quick operator review (defaults to `_bmad_output/evidence/closeout`) |
 | `mise run bmad:gh-readonly-status -- issue-view <id> \| pr-view <id> \| repo-view` | read-only JSON status helper with bounded retry for transient `gh` API connectivity errors |
 | `mise run bmad:retrigger-pr-checks -- <pr> [--workflow ci.yml] [--dry-run]` | dispatch CI workflow for PR head branch without no-op commit retriggers |
+| `mise run bmad:preflight-strict-clean -- [--repo <path>]` | strict-clean preflight gate; emits actionable JSON and fails fast when worktree is dirty |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |
@@ -73,8 +74,9 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-closeout-artifact-summary` | local validation for closeout artifact write path + summary visibility contract |
 | `mise run smoketest:bmad-repo-health-retry` | local validation for bounded transient retry behavior in `cli/bb.py repo-health` gh read paths |
 | `mise run smoketest:bmad-gh-readonly-status` | local validation for bounded transient retry behavior in read-only issue/pr status helper |
+| `mise run smoketest:bmad-preflight-strict-clean` | local validation for strict-clean preflight helper JSON/exit contract (clean pass + dirty fail) |
 | `mise run smoketest:hermes-runtime-hygiene` | local validation for Hermes runtime ignore contract (runtime state ignored, skeleton trackable) |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status/hermes-runtime-hygiene, fail-fast) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status/preflight-strict-clean/hermes-runtime-hygiene, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline
@@ -96,6 +98,7 @@ alongside each service, using Holyfields-generated publishers.
 - `repo-health` applies bounded retries for transient GitHub API connectivity errors on read-only `gh` status calls (`issue list`, `pr list`, `pr checks`).
 - For direct automation reads of issue/PR/repo state, prefer `mise run bmad:gh-readonly-status -- issue-view <id>|pr-view <id>|repo-view` over raw `gh ... view`.
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
+- Before mutating loop actions (branch/commit/merge), run `mise run bmad:preflight-strict-clean` and treat non-zero as a hard blocker requiring hygiene routing.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.

--- a/_bmad_output/issue-160-execution.md
+++ b/_bmad_output/issue-160-execution.md
@@ -1,0 +1,27 @@
+# Issue 160 — execution closeout
+
+## Ticket
+- Issue: #160
+- Title: Add explicit strict-clean preflight helper for BMAD operator loops
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added strict-clean preflight helper `ops/bmad/preflight_strict_clean.py` that wraps `repo-health --require-clean-worktree` and emits actionable JSON (`ok`, `worktree_dirty`, `blocking_reason`, errors).
+- Added deterministic contract smoke test `ops/smoketest/smoketest-bmad-preflight-strict-clean.sh` covering both clean-pass and dirty-fail paths.
+- Wired helper + smoke task into `mise.toml`, and updated operator docs (`AGENTS.md`, `ops/bmad/clean-worktree-automation.md`) to make preflight mandatory before mutating loop actions.
+
+## Out of scope
+- Automatic hygiene remediation actions (ticketing/routing automation remains manual policy).
+
+## Verification evidence
+- `mise run smoketest:bmad-preflight-strict-clean` → `PASS`
+- `python3 -m py_compile ops/bmad/preflight_strict_clean.py` → success
+- `mise run bmad:preflight-strict-clean` (on dirty working branch) → exit `1` with `blocking_reason: worktree_dirty`
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/160
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Helper is read-only and intentionally fails fast when strict-clean gate is not met.

--- a/mise.toml
+++ b/mise.toml
@@ -92,6 +92,10 @@ run = "python3 ops/bmad/gh_readonly_status.py"
 description = "Dispatch CI workflow for a PR head branch (no empty commit retrigger)"
 run = "python3 ops/bmad/retrigger_pr_checks.py"
 
+[tasks."bmad:preflight-strict-clean"]
+description = "Strict-clean BMAD preflight gate; fails fast with actionable JSON when worktree is dirty"
+run = "python3 ops/bmad/preflight_strict_clean.py"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"
@@ -164,13 +168,17 @@ run = "bash ops/smoketest/smoketest-bmad-repo-health-retry.sh"
 description = "Local smoke test for read-only gh status helper retry behavior"
 run = "bash ops/smoketest/smoketest-bmad-gh-readonly-status.sh"
 
+[tasks."smoketest:bmad-preflight-strict-clean"]
+description = "Local smoke test for strict-clean BMAD preflight helper JSON contract"
+run = "bash ops/smoketest/smoketest-bmad-preflight-strict-clean.sh"
+
 [tasks."smoketest:hermes-runtime-hygiene"]
 description = "Local smoke test for Hermes runtime ignore/track contract"
 run = "bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:hermes-runtime-hygiene"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:hermes-runtime-hygiene"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/clean-worktree-automation.md
+++ b/ops/bmad/clean-worktree-automation.md
@@ -5,6 +5,7 @@ Use this when your primary checkout is dirty and/or behind origin, and you need 
 ## Guardrails
 
 - Never stash, discard, or rewrite unknown local changes in the primary checkout.
+- Run `mise run bmad:preflight-strict-clean` before mutating actions; non-zero means stop and route hygiene first.
 - Run automation work in a dedicated clean worktree created from `origin/main`.
 - Verify the automation worktree is clean and synced before creating ticket branches.
 - Keep primary checkout untouched; remove the temporary worktree when done.

--- a/ops/bmad/preflight_strict_clean.py
+++ b/ops/bmad/preflight_strict_clean.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Strict-clean preflight gate for BMAD operator loops.
+
+Runs repo-health strict mode and returns a compact JSON contract suitable for
+automation loops before mutating actions (branching/commits/PR merges).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _run_repo_health_strict(repo: Path) -> subprocess.CompletedProcess[str]:
+    cli = repo / "cli" / "bb.py"
+    return subprocess.run(
+        [sys.executable, str(cli), "repo-health", "--json", "--require-clean-worktree"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(repo),
+    )
+
+
+def evaluate(repo: Path) -> tuple[int, dict[str, Any]]:
+    cp = _run_repo_health_strict(repo)
+
+    payload: dict[str, Any] = {
+        "ok": False,
+        "repo": str(repo),
+        "gate": "strict_clean_preflight",
+        "worktree_dirty": None,
+        "git_status": None,
+        "errors": [],
+        "blocking_reason": "",
+    }
+
+    raw = (cp.stdout or "").strip()
+    if not raw:
+        payload["blocking_reason"] = cp.stderr.strip() or "repo-health strict returned empty output"
+        return 1, payload
+
+    try:
+        snapshot = json.loads(raw)
+    except json.JSONDecodeError:
+        payload["blocking_reason"] = "invalid JSON from repo-health strict"
+        payload["errors"] = [cp.stderr.strip() or "json decode failed"]
+        return 1, payload
+
+    payload["worktree_dirty"] = snapshot.get("worktree_dirty")
+    payload["git_status"] = snapshot.get("git_status")
+    errors = snapshot.get("errors")
+    payload["errors"] = errors if isinstance(errors, list) else ["repo-health strict returned invalid errors field"]
+
+    if cp.returncode == 0:
+        payload["ok"] = True
+        return 0, payload
+
+    payload["blocking_reason"] = (
+        "worktree_dirty"
+        if payload["worktree_dirty"] is True
+        else (cp.stderr.strip() or "strict preflight failed")
+    )
+    return 1, payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Strict-clean BMAD preflight JSON helper")
+    parser.add_argument("--repo", default=".", help="Repository root (default: .)")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    rc, payload = evaluate(repo)
+    print(json.dumps(payload, indent=2))
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/smoketest/smoketest-bmad-preflight-strict-clean.sh
+++ b/ops/smoketest/smoketest-bmad-preflight-strict-clean.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Deterministic smoke test for strict-clean preflight helper.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+import json
+import subprocess
+
+import ops.bmad.preflight_strict_clean as p
+
+orig = p._run_repo_health_strict
+
+try:
+    # clean repo path => success
+    def fake_clean(_repo):
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "git_status": "## main...origin/main",
+                    "worktree_dirty": False,
+                    "errors": [],
+                }
+            ),
+            stderr="",
+        )
+
+    p._run_repo_health_strict = fake_clean
+    rc, payload = p.evaluate(p.Path("."))
+    assert rc == 0, (rc, payload)
+    assert payload["ok"] is True, payload
+    assert payload["worktree_dirty"] is False, payload
+
+    # dirty repo path => fail with actionable blocker
+    def fake_dirty(_repo):
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout=json.dumps(
+                {
+                    "git_status": "## main...origin/main",
+                    "worktree_dirty": True,
+                    "errors": [
+                        "worktree_dirty: ERROR (working tree is dirty but --require-clean-worktree was set)"
+                    ],
+                }
+            ),
+            stderr="",
+        )
+
+    p._run_repo_health_strict = fake_dirty
+    rc, payload = p.evaluate(p.Path("."))
+    assert rc == 1, (rc, payload)
+    assert payload["ok"] is False, payload
+    assert payload["blocking_reason"] == "worktree_dirty", payload
+    assert payload["worktree_dirty"] is True, payload
+
+finally:
+    p._run_repo_health_strict = orig
+PY
+
+echo "smoketest-bmad-preflight-strict-clean: PASS"


### PR DESCRIPTION
## Summary
- add strict-clean BMAD preflight helper (`ops/bmad/preflight_strict_clean.py`) that wraps `repo-health --require-clean-worktree`
- emit actionable JSON contract for automation (`ok`, `worktree_dirty`, `blocking_reason`, `errors`)
- add deterministic smoke coverage for clean pass + dirty fail (`smoketest:bmad-preflight-strict-clean`)
- wire helper/smoke into `mise.toml`, and update operator docs (`AGENTS.md`, `clean-worktree-automation.md`) to require preflight before mutating actions
- include BMAD closeout artifact for #160

## Verification
- `mise run smoketest:bmad-preflight-strict-clean`
- `python3 -m py_compile ops/bmad/preflight_strict_clean.py`
- `mise run bmad:preflight-strict-clean` (dirty branch expected fail with `blocking_reason: worktree_dirty`)

Closes #160
