### PR TITLE
feat: enforce strict preflight in merge entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-closeout-scaffold` | local validation for closeout scaffold helper (required id/create/no-overwrite) |
 | `mise run smoketest:bmad-closeout-loop` | local validation for unified closeout helper JSON/evidence fields |
 | `mise run smoketest:bmad-merge-pr-safe` | local validation for safe merge helper JSON/cleanup follow-up fields |
+| `mise run smoketest:bmad-merge-pr-preflight-guard` | local validation for merge helper strict-clean preflight enforcement + explicit bypass path |
 | `mise run smoketest:bmad-retrigger-pr-checks` | local validation for PR check retrigger helper JSON contract (dry-run path) |
 | `mise run smoketest:bmad-github-body-safety` | guardrail grep for risky inline `gh ... --body "..."` patterns in BMAD operator docs/scripts |
 | `mise run smoketest:bmad-closeout-cleanup-summary` | local validation for closeout cleanup summary helper JSON output contract |
@@ -76,7 +77,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-gh-readonly-status` | local validation for bounded transient retry behavior in read-only issue/pr status helper |
 | `mise run smoketest:bmad-preflight-strict-clean` | local validation for strict-clean preflight helper JSON/exit contract (clean pass + dirty fail) |
 | `mise run smoketest:hermes-runtime-hygiene` | local validation for Hermes runtime ignore contract (runtime state ignored, skeleton trackable) |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status/preflight-strict-clean/hermes-runtime-hygiene, fail-fast) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status/preflight-strict-clean/hermes-runtime-hygiene, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline

--- a/_bmad_output/issue-162-execution.md
+++ b/_bmad_output/issue-162-execution.md
@@ -1,0 +1,29 @@
+# Issue 162 — execution closeout
+
+## Ticket
+- Issue: #162
+- Title: Enforce strict-clean preflight in mutating BMAD operator entrypoints
+- Owner: hermes (pilot)
+
+## Scope completed
+- Enforced strict-clean preflight in mutating merge entrypoint `ops/bmad/merge_pr_safe.py` via `preflight_strict_clean.py` (default behavior).
+- Added explicit override path `--bypass-preflight` with audit signal in JSON output (`preflight.bypassed = true`).
+- Added deterministic guard smoke coverage `ops/smoketest/smoketest-bmad-merge-pr-preflight-guard.sh` (blocked path + bypass path), and updated existing merge smoke to run with explicit bypass.
+- Updated task/docs wiring in `mise.toml` and `AGENTS.md`.
+
+## Out of scope
+- Enforcement wiring in additional mutating entrypoints beyond `merge_pr_safe.py`.
+
+## Verification evidence
+- `mise run smoketest:bmad-merge-pr-safe` → `PASS`
+- `mise run smoketest:bmad-merge-pr-preflight-guard` → `PASS`
+- `mise run smoketest:bmad-preflight-strict-clean` → `PASS`
+- `python3 -m py_compile ops/bmad/merge_pr_safe.py ops/bmad/preflight_strict_clean.py` → success
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/162
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Merge helper now fails fast with a machine-readable `BLOCKED` report when strict-clean preflight fails.

--- a/mise.toml
+++ b/mise.toml
@@ -144,6 +144,10 @@ run = "bash ops/smoketest/smoketest-bmad-closeout-loop.sh"
 description = "Local smoke test for safe PR merge helper JSON/cleanup fields"
 run = "bash ops/smoketest/smoketest-bmad-merge-pr-safe.sh"
 
+[tasks."smoketest:bmad-merge-pr-preflight-guard"]
+description = "Local smoke test for merge helper strict-clean preflight enforcement + bypass"
+run = "bash ops/smoketest/smoketest-bmad-merge-pr-preflight-guard.sh"
+
 [tasks."smoketest:bmad-retrigger-pr-checks"]
 description = "Local smoke test for PR check retrigger helper JSON contract (dry-run)"
 run = "bash ops/smoketest/smoketest-bmad-retrigger-pr-checks.sh"
@@ -178,7 +182,7 @@ run = "bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:hermes-runtime-hygiene"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:hermes-runtime-hygiene"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/merge_pr_safe.py
+++ b/ops/bmad/merge_pr_safe.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Safely merge a PR for operator loops, tolerating linked-worktree delete edge cases.
 
+- Enforces strict-clean preflight gate by default (`preflight_strict_clean.py`).
+- Supports explicit `--bypass-preflight` override for intentional/manual exceptions.
 - Attempts squash merge + remote branch delete.
 - Verifies merged state independently via `gh pr view`.
 - Treats local branch/worktree cleanup as best-effort follow-up.
@@ -89,10 +91,68 @@ def worktree_paths_for_branch(branch: str) -> list[str]:
     return paths
 
 
+def run_preflight(repo: Path) -> tuple[int, dict[str, object]]:
+    helper = Path(__file__).with_name("preflight_strict_clean.py")
+    cp = subprocess.run(
+        [sys.executable, str(helper), "--repo", str(repo)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    raw = (cp.stdout or "").strip()
+    if not raw:
+        return cp.returncode or 1, {
+            "ok": False,
+            "gate": "strict_clean_preflight",
+            "blocking_reason": cp.stderr.strip() or "empty preflight output",
+        }
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return cp.returncode or 1, {
+            "ok": False,
+            "gate": "strict_clean_preflight",
+            "blocking_reason": "invalid JSON from preflight helper",
+            "stderr": cp.stderr.strip(),
+        }
+
+    return cp.returncode, payload
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Safe PR merge helper for operator loops")
     parser.add_argument("pr", help="PR number or URL")
+    parser.add_argument(
+        "--bypass-preflight",
+        action="store_true",
+        help="Bypass strict-clean preflight gate (use only for intentional/manual override)",
+    )
     args = parser.parse_args()
+
+    preflight_payload: dict[str, object] = {"ok": None, "bypassed": bool(args.bypass_preflight)}
+    if not args.bypass_preflight:
+        preflight_rc, preflight_payload = run_preflight(Path.cwd())
+        if preflight_rc != 0:
+            report = {
+                "pr": args.pr,
+                "url": None,
+                "state": "BLOCKED",
+                "mergedAt": None,
+                "merge_command_exit": None,
+                "merge_command_stderr": "",
+                "head_branch": None,
+                "preflight": preflight_payload,
+                "cleanup": {
+                    "local_branch_status": "not_applicable",
+                    "local_branch_deleted": None,
+                    "linked_worktrees": [],
+                    "followup_commands": [],
+                },
+            }
+            print(json.dumps(report, indent=2))
+            return 1
 
     merge = run("gh", "pr", "merge", args.pr, "--squash", "--delete-branch")
 
@@ -121,6 +181,7 @@ def main() -> int:
         "merge_command_exit": merge.code,
         "merge_command_stderr": merge.err,
         "head_branch": head_branch,
+        "preflight": preflight_payload,
         "cleanup": {
             "local_branch_status": "not_applicable",
             "local_branch_deleted": None,

--- a/ops/smoketest/smoketest-bmad-merge-pr-preflight-guard.sh
+++ b/ops/smoketest/smoketest-bmad-merge-pr-preflight-guard.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Deterministic smoke test for merge_pr_safe strict-clean preflight enforcement.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+import contextlib
+import io
+import json
+import sys
+
+import ops.bmad.merge_pr_safe as m
+
+orig_run_preflight = m.run_preflight
+orig_run = m.run
+orig_gh_pr_view = m.gh_pr_view
+orig_branch_exists = m.branch_exists_local
+orig_argv = sys.argv[:]
+
+try:
+    # Case 1: preflight fails and blocks merge when no bypass flag provided.
+    m.run_preflight = lambda _repo: (1, {"ok": False, "blocking_reason": "worktree_dirty"})
+    sys.argv = ["merge_pr_safe.py", "123"]
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = m.main()
+    payload = json.loads(buf.getvalue())
+    assert rc == 1, (rc, payload)
+    assert payload["state"] == "BLOCKED", payload
+    assert payload["preflight"]["blocking_reason"] == "worktree_dirty", payload
+
+    # Case 2: bypass flag skips preflight and proceeds through merge contract.
+    m.run_preflight = lambda _repo: (_ for _ in ()).throw(RuntimeError("should not be called"))
+    m.run = lambda *_args: m.CmdResult(code=0, out="", err="")
+    m.gh_pr_view = lambda _pr: {
+        "number": 123,
+        "state": "MERGED",
+        "mergedAt": "2026-01-01T00:00:00Z",
+        "url": "https://example.test/pr/123",
+        "headRefName": "fix/branch",
+    }
+    m.branch_exists_local = lambda _branch: False
+
+    sys.argv = ["merge_pr_safe.py", "123", "--bypass-preflight"]
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = m.main()
+    payload = json.loads(buf.getvalue())
+    assert rc == 0, (rc, payload)
+    assert payload["state"] == "MERGED", payload
+    assert payload["preflight"]["bypassed"] is True, payload
+
+finally:
+    m.run_preflight = orig_run_preflight
+    m.run = orig_run
+    m.gh_pr_view = orig_gh_pr_view
+    m.branch_exists_local = orig_branch_exists
+    sys.argv = orig_argv
+PY
+
+echo "smoketest-bmad-merge-pr-preflight-guard: PASS"

--- a/ops/smoketest/smoketest-bmad-merge-pr-safe.sh
+++ b/ops/smoketest/smoketest-bmad-merge-pr-safe.sh
@@ -10,7 +10,7 @@ cd "${BLOODBANK_ROOT}"
 
 MERGED_PR="${MERGED_PR:-117}"
 
-merge_json="$(python3 ops/bmad/merge_pr_safe.py "${MERGED_PR}")"
+merge_json="$(python3 ops/bmad/merge_pr_safe.py "${MERGED_PR}" --bypass-preflight)"
 
 python3 - <<'PY' "${merge_json}"
 import json
@@ -24,6 +24,7 @@ for key in [
     "merge_command_stderr",
     "head_branch",
     "cleanup",
+    "preflight",
 ]:
     assert key in payload, payload
 
@@ -34,6 +35,10 @@ assert isinstance(payload["merge_command_stderr"], str), payload
 
 if payload["head_branch"] is not None:
     assert isinstance(payload["head_branch"], str), payload
+
+preflight = payload["preflight"]
+assert isinstance(preflight, dict), payload
+assert preflight.get("bypassed") is True, payload
 
 cleanup = payload["cleanup"]
 assert isinstance(cleanup, dict), payload


### PR DESCRIPTION
## Summary
- enforce strict-clean preflight in `ops/bmad/merge_pr_safe.py` before mutating merge actions
- add explicit override `--bypass-preflight` with machine-readable audit signal (`preflight.bypassed`)
- return `BLOCKED` JSON report when preflight fails instead of attempting merge
- add deterministic preflight-guard smoke coverage (`smoketest:bmad-merge-pr-preflight-guard`)
- update existing merge smoke to use explicit bypass path and update task/docs wiring
- include BMAD closeout artifact for #162

## Verification
- `mise run smoketest:bmad-merge-pr-safe`
- `mise run smoketest:bmad-merge-pr-preflight-guard`
- `mise run smoketest:bmad-preflight-strict-clean`
- `python3 -m py_compile ops/bmad/merge_pr_safe.py ops/bmad/preflight_strict_clean.py`

Closes #162
