### PR TITLE
feat: add helper for patch-equivalent main divergence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run bmad:gh-readonly-status -- issue-view <id> \| pr-view <id> \| repo-view` | read-only JSON status helper with bounded retry for transient `gh` API connectivity errors |
 | `mise run bmad:retrigger-pr-checks -- <pr> [--workflow ci.yml] [--dry-run]` | dispatch CI workflow for PR head branch without no-op commit retriggers |
 | `mise run bmad:preflight-strict-clean -- [--repo <path>]` | strict-clean preflight gate; emits actionable JSON and fails fast when worktree is dirty |
+| `mise run bmad:reconcile-main-divergence -- [--repo <path>] [--apply]` | detect/optionally reconcile patch-equivalent `main...origin/main` divergence |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |
@@ -76,8 +77,9 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-repo-health-retry` | local validation for bounded transient retry behavior in `cli/bb.py repo-health` gh read paths |
 | `mise run smoketest:bmad-gh-readonly-status` | local validation for bounded transient retry behavior in read-only issue/pr status helper |
 | `mise run smoketest:bmad-preflight-strict-clean` | local validation for strict-clean preflight helper JSON/exit contract (clean pass + dirty fail) |
+| `mise run smoketest:bmad-reconcile-main-divergence` | local validation for patch-equivalent `main` divergence detection/reconcile contract |
 | `mise run smoketest:hermes-runtime-hygiene` | local validation for Hermes runtime ignore contract (runtime state ignored, skeleton trackable) |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status/preflight-strict-clean/hermes-runtime-hygiene, fail-fast) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status/preflight-strict-clean/reconcile-main-divergence/hermes-runtime-hygiene, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline
@@ -101,6 +103,7 @@ alongside each service, using Holyfields-generated publishers.
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.
 - Before mutating loop actions (branch/commit/merge), run `mise run bmad:preflight-strict-clean` and treat non-zero as a hard blocker requiring hygiene routing.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.
+- If `main` is `ahead` and `behind` with patch-equivalent divergence, use `mise run bmad:reconcile-main-divergence` to confirm and optionally apply safe local reconciliation.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.
 - If primary checkout is dirty/behind, use the dedicated clean-worktree automation path in `ops/bmad/clean-worktree-automation.md` (do not stash/discard unknown local changes).

--- a/_bmad_output/issue-164-execution.md
+++ b/_bmad_output/issue-164-execution.md
@@ -1,0 +1,27 @@
+# Issue 164 — execution closeout
+
+## Ticket
+- Issue: #164
+- Title: Handle post-merge main divergence (ahead/behind equivalent patch) in operator loops
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added `ops/bmad/reconcile_main_divergence.py` to detect local `main...origin/main` divergence and classify patch-equivalent drift.
+- Added optional `--apply` path (guarded) to reconcile only when on `main` and divergence is patch-equivalent.
+- Added deterministic smoke test `ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh` and documented/wired task surface in `mise.toml` and `AGENTS.md`.
+
+## Out of scope
+- Automatic invocation of reconcile helper from all loop entrypoints.
+
+## Verification evidence
+- `bash ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh` → `PASS`
+- `python3 -m py_compile ops/bmad/reconcile_main_divergence.py` → success
+- `python3 ops/bmad/reconcile_main_divergence.py --repo /home/delorenj/code/33GOD/bloodbank` → `ahead: 1`, `behind: 1`, `patch_equivalent_divergence: true`, recommended reset action
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/164
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Helper defaults to read-only; `--apply` is explicit and guarded.

--- a/mise.toml
+++ b/mise.toml
@@ -96,6 +96,10 @@ run = "python3 ops/bmad/retrigger_pr_checks.py"
 description = "Strict-clean BMAD preflight gate; fails fast with actionable JSON when worktree is dirty"
 run = "python3 ops/bmad/preflight_strict_clean.py"
 
+[tasks."bmad:reconcile-main-divergence"]
+description = "Detect/optionally reconcile patch-equivalent local main divergence vs origin/main"
+run = "python3 ops/bmad/reconcile_main_divergence.py"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"
@@ -176,13 +180,17 @@ run = "bash ops/smoketest/smoketest-bmad-gh-readonly-status.sh"
 description = "Local smoke test for strict-clean BMAD preflight helper JSON contract"
 run = "bash ops/smoketest/smoketest-bmad-preflight-strict-clean.sh"
 
+[tasks."smoketest:bmad-reconcile-main-divergence"]
+description = "Local smoke test for patch-equivalent main divergence detection/reconcile helper"
+run = "bash ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh"
+
 [tasks."smoketest:hermes-runtime-hygiene"]
 description = "Local smoke test for Hermes runtime ignore/track contract"
 run = "bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:hermes-runtime-hygiene"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:hermes-runtime-hygiene"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/reconcile_main_divergence.py
+++ b/ops/bmad/reconcile_main_divergence.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Detect and optionally reconcile patch-equivalent local main divergence.
+
+Default mode is read-only. Use --apply to hard-reset local main to origin/main
+only when divergence is patch-equivalent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(repo: Path, *cmd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(repo), text=True, capture_output=True, check=False)
+
+
+def _branch(repo: Path) -> str:
+    cp = _run(repo, "git", "rev-parse", "--abbrev-ref", "HEAD")
+    return cp.stdout.strip() if cp.returncode == 0 else ""
+
+
+def evaluate(repo: Path) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "ok": False,
+        "repo": str(repo),
+        "branch": _branch(repo),
+        "ahead": None,
+        "behind": None,
+        "patch_equivalent_divergence": False,
+        "recommended_action": None,
+        "applied": False,
+        "errors": [],
+    }
+
+    _run(repo, "git", "fetch", "origin", "main")
+
+    counts = _run(repo, "git", "rev-list", "--left-right", "--count", "main...origin/main")
+    if counts.returncode != 0:
+        payload["errors"] = [counts.stderr.strip() or "rev-list failed"]
+        return payload
+
+    left, right = counts.stdout.strip().split()
+    ahead = int(left)
+    behind = int(right)
+    payload["ahead"] = ahead
+    payload["behind"] = behind
+
+    cherry = _run(repo, "git", "log", "--left-right", "--cherry-pick", "--oneline", "main...origin/main")
+    if cherry.returncode != 0:
+        payload["errors"] = [cherry.stderr.strip() or "cherry-pick log failed"]
+        return payload
+
+    patch_equiv = ahead > 0 and behind > 0 and cherry.stdout.strip() == ""
+    payload["patch_equivalent_divergence"] = patch_equiv
+
+    if ahead == 0 and behind == 0:
+        payload["ok"] = True
+        payload["recommended_action"] = "none"
+        return payload
+
+    if patch_equiv:
+        payload["recommended_action"] = "git checkout main && git reset --hard origin/main"
+    elif behind > 0 and ahead == 0:
+        payload["recommended_action"] = "git checkout main && git pull --ff-only"
+    else:
+        payload["recommended_action"] = "manual_rebase_or_merge_review"
+
+    payload["ok"] = True
+    return payload
+
+
+def apply_if_safe(repo: Path, payload: dict[str, object]) -> tuple[bool, str]:
+    if payload.get("branch") != "main":
+        return False, "apply requires current branch = main"
+    if payload.get("patch_equivalent_divergence") is not True:
+        return False, "apply allowed only for patch-equivalent divergence"
+
+    cp = _run(repo, "git", "reset", "--hard", "origin/main")
+    if cp.returncode != 0:
+        return False, cp.stderr.strip() or "git reset --hard failed"
+    return True, "applied"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect/reconcile patch-equivalent main divergence")
+    parser.add_argument("--repo", default=".", help="Repo root (default: .)")
+    parser.add_argument("--apply", action="store_true", help="Apply safe reconciliation when eligible")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    payload = evaluate(repo)
+
+    if args.apply:
+        ok, msg = apply_if_safe(repo, payload)
+        payload["applied"] = ok
+        if not ok:
+            errs = payload.get("errors")
+            if isinstance(errs, list):
+                errs.append(msg)
+            else:
+                payload["errors"] = [msg]
+            print(json.dumps(payload, indent=2))
+            return 1
+
+        payload = evaluate(repo)
+        payload["applied"] = True
+
+    print(json.dumps(payload, indent=2))
+    return 0 if payload.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh
+++ b/ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Deterministic smoke test for reconcile_main_divergence helper.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+import subprocess
+
+import ops.bmad.reconcile_main_divergence as h
+
+orig_run = h._run
+orig_branch = h._branch
+
+try:
+    # Simulate patch-equivalent divergence (ahead 1 / behind 1, empty cherry output)
+    calls = []
+
+    def fake_run(_repo, *cmd):
+        calls.append(cmd)
+        if cmd[:3] == ("git", "rev-list", "--left-right"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="1 1\n", stderr="")
+        if cmd[:4] == ("git", "log", "--left-right", "--cherry-pick"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    h._run = fake_run
+    h._branch = lambda _repo: "main"
+
+    payload = h.evaluate(h.Path("."))
+    assert payload["ok"] is True, payload
+    assert payload["ahead"] == 1 and payload["behind"] == 1, payload
+    assert payload["patch_equivalent_divergence"] is True, payload
+    assert "reset --hard origin/main" in str(payload["recommended_action"]), payload
+
+    # Simulate safe apply success
+    def fake_run_apply(_repo, *cmd):
+        if cmd[:3] == ("git", "rev-list", "--left-right"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="1 1\n", stderr="")
+        if cmd[:4] == ("git", "log", "--left-right", "--cherry-pick"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        if cmd[:3] == ("git", "reset", "--hard"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    h._run = fake_run_apply
+    ok, msg = h.apply_if_safe(h.Path("."), payload)
+    assert ok is True and msg == "applied", (ok, msg)
+
+finally:
+    h._run = orig_run
+    h._branch = orig_branch
+PY
+
+echo "smoketest-bmad-reconcile-main-divergence: PASS"


### PR DESCRIPTION
## Summary
- add `ops/bmad/reconcile_main_divergence.py` to detect `main...origin/main` divergence and classify patch-equivalent drift
- add optional guarded `--apply` reconciliation path (main-only + patch-equivalent-only)
- add deterministic smoke coverage (`smoketest-bmad-reconcile-main-divergence`)
- wire task/docs updates in `mise.toml` and `AGENTS.md`
- include BMAD closeout artifact for #164

## Verification
- `bash ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh`
- `python3 -m py_compile ops/bmad/reconcile_main_divergence.py`
- `python3 ops/bmad/reconcile_main_divergence.py --repo /home/delorenj/code/33GOD/bloodbank`

Closes #164
