### PR TITLE
feat: add commit-side summaries to divergence helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run bmad:gh-readonly-status -- issue-view <id> \| pr-view <id> \| repo-view` | read-only JSON status helper with bounded retry for transient `gh` API connectivity errors |
 | `mise run bmad:retrigger-pr-checks -- <pr> [--workflow ci.yml] [--dry-run]` | dispatch CI workflow for PR head branch without no-op commit retriggers |
 | `mise run bmad:preflight-strict-clean -- [--repo <path>]` | strict-clean preflight gate; emits actionable JSON and fails fast when worktree is dirty |
-| `mise run bmad:reconcile-main-divergence -- [--repo <path>] [--apply]` | detect/optionally reconcile patch-equivalent `main...origin/main` divergence |
+| `mise run bmad:reconcile-main-divergence -- [--repo <path>] [--apply] [--limit <n>]` | detect/optionally reconcile patch-equivalent `main...origin/main` divergence with commit-side summaries |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |

--- a/_bmad_output/issue-168-execution.md
+++ b/_bmad_output/issue-168-execution.md
@@ -1,0 +1,27 @@
+# Issue 168 — execution closeout
+
+## Ticket
+- Issue: #168
+- Title: Execute post-merge main reconciliation helper on primary checkout
+- Owner: hermes (pilot)
+
+## Scope completed
+- Extended `ops/bmad/reconcile_main_divergence.py` with divergence side summaries (`ahead_commits`, `behind_commits`) and `--limit` control.
+- Updated deterministic smoke test `ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh` to validate commit-side summaries.
+- Updated AGENTS task contract to include `--limit` and summarize new helper output intent.
+
+## Out of scope
+- Automatic repair for non patch-equivalent divergence (`manual_rebase_or_merge_review` remains explicit recommendation).
+
+## Verification evidence
+- `bash ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh` → `PASS`
+- `python3 -m py_compile ops/bmad/reconcile_main_divergence.py` → success
+- `python3 ops/bmad/reconcile_main_divergence.py --repo /home/delorenj/code/33GOD/bloodbank --limit 5` → reports `ahead_commits`/`behind_commits` with manual reconciliation recommendation
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/168
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- This gives immediate operator evidence for the non-patch-equivalent blocker without mutating primary checkout.

--- a/ops/bmad/reconcile_main_divergence.py
+++ b/ops/bmad/reconcile_main_divergence.py
@@ -23,7 +23,14 @@ def _branch(repo: Path) -> str:
     return cp.stdout.strip() if cp.returncode == 0 else ""
 
 
-def evaluate(repo: Path) -> dict[str, object]:
+def _collect_commits(repo: Path, expr: str, limit: int) -> list[str]:
+    cp = _run(repo, "git", "log", "--oneline", f"--max-count={limit}", expr)
+    if cp.returncode != 0 or not cp.stdout.strip():
+        return []
+    return [line.strip() for line in cp.stdout.splitlines() if line.strip()]
+
+
+def evaluate(repo: Path, limit: int = 10) -> dict[str, object]:
     payload: dict[str, object] = {
         "ok": False,
         "repo": str(repo),
@@ -33,6 +40,8 @@ def evaluate(repo: Path) -> dict[str, object]:
         "patch_equivalent_divergence": False,
         "recommended_action": None,
         "applied": False,
+        "ahead_commits": [],
+        "behind_commits": [],
         "errors": [],
     }
 
@@ -56,6 +65,9 @@ def evaluate(repo: Path) -> dict[str, object]:
 
     patch_equiv = ahead > 0 and behind > 0 and cherry.stdout.strip() == ""
     payload["patch_equivalent_divergence"] = patch_equiv
+
+    payload["ahead_commits"] = _collect_commits(repo, "origin/main..main", limit)
+    payload["behind_commits"] = _collect_commits(repo, "main..origin/main", limit)
 
     if ahead == 0 and behind == 0:
         payload["ok"] = True
@@ -89,10 +101,16 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Detect/reconcile patch-equivalent main divergence")
     parser.add_argument("--repo", default=".", help="Repo root (default: .)")
     parser.add_argument("--apply", action="store_true", help="Apply safe reconciliation when eligible")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Max commit summaries per divergence side in output (default: 10)",
+    )
     args = parser.parse_args()
 
     repo = Path(args.repo).resolve()
-    payload = evaluate(repo)
+    payload = evaluate(repo, limit=max(1, args.limit))
 
     if args.apply:
         ok, msg = apply_if_safe(repo, payload)
@@ -106,7 +124,7 @@ def main() -> int:
             print(json.dumps(payload, indent=2))
             return 1
 
-        payload = evaluate(repo)
+        payload = evaluate(repo, limit=max(1, args.limit))
         payload["applied"] = True
 
     print(json.dumps(payload, indent=2))

--- a/ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh
+++ b/ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh
@@ -24,6 +24,10 @@ try:
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="1 1\n", stderr="")
         if cmd[:4] == ("git", "log", "--left-right", "--cherry-pick"):
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        if cmd[:3] == ("git", "log", "--oneline") and cmd[-1] == "origin/main..main":
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="a1 local commit\n", stderr="")
+        if cmd[:3] == ("git", "log", "--oneline") and cmd[-1] == "main..origin/main":
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="b1 remote commit\n", stderr="")
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
     h._run = fake_run
@@ -33,6 +37,8 @@ try:
     assert payload["ok"] is True, payload
     assert payload["ahead"] == 1 and payload["behind"] == 1, payload
     assert payload["patch_equivalent_divergence"] is True, payload
+    assert payload["ahead_commits"] == ["a1 local commit"], payload
+    assert payload["behind_commits"] == ["b1 remote commit"], payload
     assert "reset --hard origin/main" in str(payload["recommended_action"]), payload
 
     # Simulate safe apply success
@@ -40,6 +46,8 @@ try:
         if cmd[:3] == ("git", "rev-list", "--left-right"):
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="1 1\n", stderr="")
         if cmd[:4] == ("git", "log", "--left-right", "--cherry-pick"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        if cmd[:3] == ("git", "log", "--oneline") and cmd[-1] in {"origin/main..main", "main..origin/main"}:
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
         if cmd[:3] == ("git", "reset", "--hard"):
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")


### PR DESCRIPTION
## Summary
- extend `reconcile_main_divergence.py` with commit-side divergence summaries (`ahead_commits`, `behind_commits`)
- add `--limit` control for commit summary output size
- update deterministic smoke coverage to validate commit-side summaries
- update AGENTS task contract for new helper output surface
- include BMAD closeout artifact for #168

## Verification
- `bash ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh`
- `python3 -m py_compile ops/bmad/reconcile_main_divergence.py`
- `python3 ops/bmad/reconcile_main_divergence.py --repo /home/delorenj/code/33GOD/bloodbank --limit 5`

Closes #168
