### PR TITLE
feat: add primary checkout recovery diagnostics + runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run bmad:retrigger-pr-checks -- <pr> [--workflow ci.yml] [--dry-run]` | dispatch CI workflow for PR head branch without no-op commit retriggers |
 | `mise run bmad:preflight-strict-clean -- [--repo <path>]` | strict-clean preflight gate; emits actionable JSON and fails fast when worktree is dirty |
 | `mise run bmad:reconcile-main-divergence -- [--repo <path>] [--apply] [--limit <n>]` | detect/optionally reconcile patch-equivalent `main...origin/main` divergence with commit-side summaries |
+| `mise run bmad:primary-recovery-check -- [--repo <path>]` | read-only divergence diagnostics + helper-availability check for primary checkout recovery |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |
@@ -78,6 +79,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-gh-readonly-status` | local validation for bounded transient retry behavior in read-only issue/pr status helper |
 | `mise run smoketest:bmad-preflight-strict-clean` | local validation for strict-clean preflight helper JSON/exit contract (clean pass + dirty fail) |
 | `mise run smoketest:bmad-reconcile-main-divergence` | local validation for patch-equivalent `main` divergence detection/reconcile contract |
+| `mise run smoketest:bmad-primary-recovery-check` | local validation for read-only primary checkout recovery diagnostics contract |
 | `mise run smoketest:hermes-runtime-hygiene` | local validation for Hermes runtime ignore contract (runtime state ignored, skeleton trackable) |
 | `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status/preflight-strict-clean/reconcile-main-divergence/hermes-runtime-hygiene, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
@@ -104,6 +106,7 @@ alongside each service, using Holyfields-generated publishers.
 - Before mutating loop actions (branch/commit/merge), run `mise run bmad:preflight-strict-clean` and treat non-zero as a hard blocker requiring hygiene routing.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.
 - If `main` is `ahead` and `behind` with patch-equivalent divergence, use `mise run bmad:reconcile-main-divergence` to confirm and optionally apply safe local reconciliation.
+- If helper files are missing locally while `main` is diverged, run `mise run bmad:primary-recovery-check` then follow `ops/bmad/primary-checkout-recovery.md` before any destructive sync action.
 - `bmad:pr-merge-safe` now attempts safe post-merge reconciliation by default; use `--no-reconcile-main` only when you explicitly need to defer reconciliation.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.

--- a/_bmad_output/issue-170-execution.md
+++ b/_bmad_output/issue-170-execution.md
@@ -1,0 +1,27 @@
+# Issue 170 — execution closeout
+
+## Ticket
+- Issue: #170
+- Title: Recover helper availability when primary checkout diverges from merged BMAD updates
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added read-only diagnostics helper: `ops/bmad/primary_recovery_check.py`.
+- Added operator runbook for non-destructive recovery sequencing: `ops/bmad/primary-checkout-recovery.md`.
+- Registered task + smoke coverage in `mise.toml` and operator guide entries in `AGENTS.md`.
+
+## Out of scope
+- Auto-mutating recovery for non patch-equivalent divergence (remains manual decision path).
+
+## Verification evidence
+- `bash ops/smoketest/smoketest-bmad-primary-recovery-check.sh` → PASS
+- `python3 -m py_compile ops/bmad/primary_recovery_check.py` → success
+- `python3 ops/bmad/primary_recovery_check.py --repo /home/delorenj/code/33GOD/bloodbank` → reports `helper_local_exists=false`, `helper_on_origin_main=true`, `recommended_path=manual_rebase_or_backup_then_reset`
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/170
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Primary checkout drift worsened from behind 3 to behind 4 during loop window due additional upstream merges.

--- a/mise.toml
+++ b/mise.toml
@@ -100,6 +100,10 @@ run = "python3 ops/bmad/preflight_strict_clean.py"
 description = "Detect/optionally reconcile patch-equivalent local main divergence vs origin/main"
 run = "python3 ops/bmad/reconcile_main_divergence.py"
 
+[tasks."bmad:primary-recovery-check"]
+description = "Read-only diagnostics for recovering a diverged primary checkout when helper files are missing"
+run = "python3 ops/bmad/primary_recovery_check.py"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"
@@ -184,13 +188,17 @@ run = "bash ops/smoketest/smoketest-bmad-preflight-strict-clean.sh"
 description = "Local smoke test for patch-equivalent main divergence detection/reconcile helper"
 run = "bash ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh"
 
+[tasks."smoketest:bmad-primary-recovery-check"]
+description = "Local smoke test for read-only primary checkout recovery diagnostics helper"
+run = "bash ops/smoketest/smoketest-bmad-primary-recovery-check.sh"
+
 [tasks."smoketest:hermes-runtime-hygiene"]
 description = "Local smoke test for Hermes runtime ignore/track contract"
 run = "bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:hermes-runtime-hygiene"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:hermes-runtime-hygiene"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/primary-checkout-recovery.md
+++ b/ops/bmad/primary-checkout-recovery.md
@@ -1,0 +1,73 @@
+# Primary checkout recovery runbook (diverged `main`)
+
+Use this when your primary checkout is ahead/behind `origin/main` and merged BMAD helper files are missing locally.
+
+## 0) Read-only diagnostics (required)
+
+```bash
+mise run bmad:primary-recovery-check -- --repo /path/to/primary/checkout
+```
+
+This emits:
+- `ahead` / `behind`
+- `patch_equivalent_divergence`
+- `helper_local_exists`
+- `helper_on_origin_main`
+- `recommended_path`
+
+## 1) Safety anchor before any destructive action
+
+```bash
+cd /path/to/primary/checkout
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+git branch "backup/main-divergence-${TS}" main
+git bundle create "/tmp/bloodbank-main-${TS}.bundle" main "backup/main-divergence-${TS}"
+```
+
+Do **not** skip this backup.
+
+## 2) Recovery paths
+
+### A) Patch-equivalent divergence + helper present
+
+```bash
+python3 ops/bmad/reconcile_main_divergence.py --repo /path/to/primary/checkout --apply
+```
+
+### B) Patch-equivalent divergence + helper missing locally but exists on `origin/main`
+
+1. Align local `main` to `origin/main` **after backup**:
+
+```bash
+git checkout main
+git fetch origin main
+git reset --hard origin/main
+```
+
+2. Re-run diagnostics and helper:
+
+```bash
+mise run bmad:primary-recovery-check -- --repo /path/to/primary/checkout
+python3 ops/bmad/reconcile_main_divergence.py --repo /path/to/primary/checkout --apply
+```
+
+### C) Non patch-equivalent divergence (`recommended_path=manual_rebase_or_backup_then_reset`)
+
+Use one of:
+- rebase/local-history repair path, or
+- backup then reset to canonical `origin/main`.
+
+This is a **manual decision point** and should be ticketed/evidenced.
+
+## 3) Post-recovery verification
+
+```bash
+git status -sb
+python3 cli/bb.py repo-health --json --require-clean-worktree
+```
+
+Target state:
+- `main...origin/main` (no ahead/behind)
+- `worktree_dirty=false`
+- helper files available locally.

--- a/ops/bmad/primary_recovery_check.py
+++ b/ops/bmad/primary_recovery_check.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Read-only diagnostics for recovering a diverged primary checkout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def _run(repo: Path, *cmd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(repo), capture_output=True, text=True, check=False)
+
+
+def _exists_on_ref(repo: Path, ref_path: str) -> bool:
+    cp = _run(repo, "git", "cat-file", "-e", ref_path)
+    return cp.returncode == 0
+
+
+def evaluate(repo: Path) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "ok": False,
+        "repo": str(repo),
+        "branch": "",
+        "git_status": "",
+        "ahead": None,
+        "behind": None,
+        "patch_equivalent_divergence": False,
+        "helper_local_exists": False,
+        "helper_on_origin_main": False,
+        "recommended_path": "",
+        "errors": [],
+    }
+
+    status = _run(repo, "git", "status", "--short", "--branch")
+    if status.returncode != 0:
+        payload["errors"].append(status.stderr.strip() or "git status failed")
+        return payload
+
+    lines = status.stdout.splitlines()
+    payload["git_status"] = lines[0] if lines else ""
+
+    branch = _run(repo, "git", "rev-parse", "--abbrev-ref", "HEAD")
+    payload["branch"] = branch.stdout.strip() if branch.returncode == 0 else ""
+
+    _run(repo, "git", "fetch", "origin", "main")
+
+    counts = _run(repo, "git", "rev-list", "--left-right", "--count", "main...origin/main")
+    if counts.returncode != 0:
+        payload["errors"].append(counts.stderr.strip() or "rev-list failed")
+        return payload
+
+    left, right = counts.stdout.strip().split()
+    ahead, behind = int(left), int(right)
+    payload["ahead"] = ahead
+    payload["behind"] = behind
+
+    cherry = _run(repo, "git", "log", "--left-right", "--cherry-pick", "--oneline", "main...origin/main")
+    if cherry.returncode != 0:
+        payload["errors"].append(cherry.stderr.strip() or "cherry log failed")
+        return payload
+
+    patch_equiv = ahead > 0 and behind > 0 and cherry.stdout.strip() == ""
+    payload["patch_equivalent_divergence"] = patch_equiv
+
+    helper_rel = Path("ops/bmad/reconcile_main_divergence.py")
+    payload["helper_local_exists"] = (repo / helper_rel).exists()
+    payload["helper_on_origin_main"] = _exists_on_ref(repo, f"origin/main:{helper_rel.as_posix()}")
+
+    if ahead == 0 and behind == 0:
+        payload["recommended_path"] = "none"
+    elif patch_equiv and payload["helper_local_exists"]:
+        payload["recommended_path"] = "run_reconcile_helper_apply"
+    elif patch_equiv and not payload["helper_local_exists"] and payload["helper_on_origin_main"]:
+        payload["recommended_path"] = "align_main_then_run_reconcile_helper"
+    elif ahead > 0 and behind > 0:
+        payload["recommended_path"] = "manual_rebase_or_backup_then_reset"
+    elif behind > 0:
+        payload["recommended_path"] = "pull_ff_only"
+    else:
+        payload["recommended_path"] = "review_local_ahead_commits"
+
+    payload["ok"] = True
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Primary checkout divergence diagnostics")
+    parser.add_argument("--repo", default=".", help="Repo root (default: .)")
+    args = parser.parse_args()
+
+    payload = evaluate(Path(args.repo).resolve())
+    print(json.dumps(payload, indent=2))
+    return 0 if payload.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/smoketest/smoketest-bmad-primary-recovery-check.sh
+++ b/ops/smoketest/smoketest-bmad-primary-recovery-check.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Deterministic smoke test for primary_recovery_check helper.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+import subprocess
+
+import ops.bmad.primary_recovery_check as h
+
+orig_run = h._run
+orig_exists = h._exists_on_ref
+
+try:
+    def fake_run(_repo, *cmd):
+        if cmd[:3] == ("git", "status", "--short"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="## main...origin/main [ahead 1, behind 3]\n", stderr="")
+        if cmd[:3] == ("git", "rev-parse", "--abbrev-ref"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="main\n", stderr="")
+        if cmd[:3] == ("git", "rev-list", "--left-right"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="1 3\n", stderr="")
+        if cmd[:4] == ("git", "log", "--left-right", "--cherry-pick"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="< a\n> b\n", stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    h._run = fake_run
+    h._exists_on_ref = lambda _repo, _ref_path: True
+
+    payload = h.evaluate(h.Path("."))
+    assert payload["ok"] is True, payload
+    assert payload["ahead"] == 1 and payload["behind"] == 3, payload
+    assert payload["patch_equivalent_divergence"] is False, payload
+    assert payload["helper_on_origin_main"] is True, payload
+    assert payload["recommended_path"] == "manual_rebase_or_backup_then_reset", payload
+
+finally:
+    h._run = orig_run
+    h._exists_on_ref = orig_exists
+PY
+
+echo "smoketest-bmad-primary-recovery-check: PASS"


### PR DESCRIPTION
## Summary
- add `ops/bmad/primary_recovery_check.py` (read-only diagnostics for diverged primary checkout)
- add `ops/bmad/primary-checkout-recovery.md` runbook with required backup-first recovery paths
- register new mise task `bmad:primary-recovery-check`
- add deterministic smoke test `smoketest:bmad-primary-recovery-check`
- document the new recovery flow in `AGENTS.md`
- include BMAD closeout artifact for #170

## Verification
- `bash ops/smoketest/smoketest-bmad-primary-recovery-check.sh`
- `python3 -m py_compile ops/bmad/primary_recovery_check.py`
- `python3 ops/bmad/primary_recovery_check.py --repo /home/delorenj/code/33GOD/bloodbank`

Closes #170
