### PR TITLE
feat: add helper availability fields to repo-health

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-closeout-cleanup-summary` | local validation for closeout cleanup summary helper JSON output contract |
 | `mise run smoketest:bmad-closeout-artifact-summary` | local validation for closeout artifact write path + summary visibility contract |
 | `mise run smoketest:bmad-repo-health-retry` | local validation for bounded transient retry behavior in `cli/bb.py repo-health` gh read paths |
+| `mise run smoketest:bmad-repo-health-helper-availability` | local validation for `repo-health` helper availability snapshot fields (`helper_local_exists`, `helper_on_origin_main`) |
 | `mise run smoketest:bmad-gh-readonly-status` | local validation for bounded transient retry behavior in read-only issue/pr status helper |
 | `mise run smoketest:bmad-preflight-strict-clean` | local validation for strict-clean preflight helper JSON/exit contract (clean pass + dirty fail) |
 | `mise run smoketest:bmad-reconcile-main-divergence` | local validation for patch-equivalent `main` divergence detection/reconcile contract |
@@ -99,7 +100,7 @@ alongside each service, using Holyfields-generated publishers.
   - follow-up ticket URL when the fix is out of current PR scope
 - For GitHub CLI reliability fallbacks (`projectCards` deprecation class), use `ops/bmad/github-cli-reliability.md` and prefer `gh ... --json` or `gh api` REST paths in automation loops.
 - For shell-safe issue/PR markdown composition, use `ops/bmad/github-body-authoring.md` and prefer `--body-file`/file-backed REST payloads over inline `--body "..."`.
-- For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal).
+- For scriptable evidence capture, use: `python3 cli/bb.py repo-health --json` (includes explicit `worktree_dirty` signal plus helper availability fields).
 - `repo-health` applies bounded retries for transient GitHub API connectivity errors on read-only `gh` status calls (`issue list`, `pr list`, `pr checks`).
 - For direct automation reads of issue/PR/repo state, prefer `mise run bmad:gh-readonly-status -- issue-view <id>|pr-view <id>|repo-view` over raw `gh ... view`.
 - For gate-style checks, add `--require-clean-worktree` to force non-zero exit on dirty trees.

--- a/_bmad_output/issue-172-execution.md
+++ b/_bmad_output/issue-172-execution.md
@@ -1,0 +1,29 @@
+# Issue 172 — execution closeout
+
+## Ticket
+- Issue: #172
+- Title: Expose BMAD helper availability in repo-health snapshot
+- Owner: hermes (pilot)
+
+## Scope completed
+- Extended `cli/bb.py repo-health` snapshot with helper diagnostics:
+  - `helper_local_exists`
+  - `helper_on_origin_main`
+- Added deterministic smoke test `ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh`.
+- Wired task docs/runner surface in `mise.toml` and `AGENTS.md`.
+
+## Out of scope
+- Auto-recovery/mutation of primary checkout divergence (still ticketed/manual path).
+
+## Verification evidence
+- `bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh` → PASS
+- `python3 -m py_compile cli/bb.py` → success
+- `python3 cli/bb.py repo-health --json --limit 1` → includes helper availability fields in output
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/172
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Improves loop routing when primary checkout is stale and merged helper paths are missing locally.

--- a/cli/bb.py
+++ b/cli/bb.py
@@ -274,6 +274,12 @@ def _write_output(path_str: str, content: str) -> str | None:
         return f"output_write: ERROR ({exc})"
 
 
+def _git_ref_path_exists(root: Path, ref: str, rel_path: str) -> bool:
+    """Return True when ``ref:rel_path`` exists in git object database."""
+    rc, _, _ = _run(root, "git", "cat-file", "-e", f"{ref}:{rel_path}")
+    return rc == 0
+
+
 def cmd_repo_health(args: argparse.Namespace) -> int:
     """Print a concise repo/ticket/PR/check snapshot for BMAD evidence."""
     root = bloodbank_root()
@@ -281,6 +287,8 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
     snapshot: dict[str, object] = {
         "git_status": None,
         "worktree_dirty": None,
+        "helper_local_exists": None,
+        "helper_on_origin_main": None,
         "issues_open": [],
         "prs_open": [],
         "latest_pr_checks": None,
@@ -311,6 +319,9 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
     git_line = git_lines[0] if git_lines else "<no status output>"
     snapshot["git_status"] = git_line
     snapshot["worktree_dirty"] = len(git_lines) > 1
+    helper_rel = "ops/bmad/reconcile_main_divergence.py"
+    snapshot["helper_local_exists"] = (root / helper_rel).is_file()
+    snapshot["helper_on_origin_main"] = _git_ref_path_exists(root, "origin/main", helper_rel)
 
     if args.require_clean_worktree and snapshot["worktree_dirty"] is True:
         cast_errors = snapshot["errors"]
@@ -402,6 +413,14 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
         lines_out: list[str] = []
         lines_out.append(f"git_status: {snapshot['git_status']}")
         lines_out.append(f"worktree_dirty: {str(snapshot['worktree_dirty']).lower()}")
+        lines_out.append(
+            "helper_local_exists: "
+            f"{str(snapshot['helper_local_exists']).lower()}"
+        )
+        lines_out.append(
+            "helper_on_origin_main: "
+            f"{str(snapshot['helper_on_origin_main']).lower()}"
+        )
 
         issues_out = snapshot["issues_open"]
         assert isinstance(issues_out, list)

--- a/mise.toml
+++ b/mise.toml
@@ -176,6 +176,10 @@ run = "bash ops/smoketest/smoketest-bmad-closeout-artifact-summary.sh"
 description = "Local smoke test for repo-health transient gh retry behavior"
 run = "bash ops/smoketest/smoketest-bmad-repo-health-retry.sh"
 
+[tasks."smoketest:bmad-repo-health-helper-availability"]
+description = "Local smoke test for repo-health helper availability snapshot fields"
+run = "bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh"
+
 [tasks."smoketest:bmad-gh-readonly-status"]
 description = "Local smoke test for read-only gh status helper retry behavior"
 run = "bash ops/smoketest/smoketest-bmad-gh-readonly-status.sh"
@@ -198,7 +202,7 @@ run = "bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:hermes-runtime-hygiene"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-repo-health-helper-availability && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:hermes-runtime-hygiene"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh
+++ b/ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Deterministic smoke test for repo-health helper availability fields.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import cli.bb as bb
+
+orig_run = bb._run
+orig_root = bb.bloodbank_root
+
+try:
+    def fake_root():
+        return Path(".").resolve()
+
+    def fake_run(_root, *argv):
+        if argv[:3] == ("git", "status", "--short"):
+            return (0, "## main...origin/main [ahead 1, behind 1]", "")
+        if argv[:4] == ("git", "cat-file", "-e", "origin/main:ops/bmad/reconcile_main_divergence.py"):
+            return (0, "", "")
+        if argv[:3] == ("gh", "issue", "list"):
+            return (0, "[]", "")
+        if argv[:3] == ("gh", "pr", "list"):
+            return (0, "[]", "")
+        return (0, "", "")
+
+    bb.bloodbank_root = fake_root
+    bb._run = fake_run
+
+    args = Namespace(limit=5, json_output=True, out_path=None, require_clean_worktree=False)
+    rc = bb.cmd_repo_health(args)
+    assert rc == 0, rc
+
+    # Re-run and capture rendered text path for non-json fields
+    args = Namespace(limit=5, json_output=False, out_path="/tmp/repo-health-helper-smoke.txt", require_clean_worktree=False)
+    rc = bb.cmd_repo_health(args)
+    assert rc == 0, rc
+
+    txt = Path("/tmp/repo-health-helper-smoke.txt").read_text(encoding="utf-8")
+    assert "helper_local_exists:" in txt, txt
+    assert "helper_on_origin_main: true" in txt, txt
+
+finally:
+    bb._run = orig_run
+    bb.bloodbank_root = orig_root
+PY
+
+echo "smoketest-bmad-repo-health-helper-availability: PASS"


### PR DESCRIPTION
## Summary
- extend `bb repo-health` snapshot with helper availability diagnostics:
  - `helper_local_exists`
  - `helper_on_origin_main`
- add deterministic smoke test `smoketest-bmad-repo-health-helper-availability`
- wire task + operator docs updates in `mise.toml` and `AGENTS.md`
- include BMAD closeout artifact for #172

## Verification
- `bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh`
- `python3 -m py_compile cli/bb.py`
- `python3 cli/bb.py repo-health --json --limit 1`

Closes #172
