### PR TITLE
feat: add backup-first diverged-main alignment helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run bmad:preflight-strict-clean -- [--repo <path>]` | strict-clean preflight gate; emits actionable JSON and fails fast when worktree is dirty |
 | `mise run bmad:reconcile-main-divergence -- [--repo <path>] [--apply] [--limit <n>]` | detect/optionally reconcile patch-equivalent `main...origin/main` divergence with commit-side summaries |
 | `mise run bmad:primary-recovery-check -- [--repo <path>]` | read-only divergence diagnostics + helper-availability check for primary checkout recovery |
+| `mise run bmad:align-main-with-backup -- [--repo <path>] [--bundle-dir <path>] [--apply]` | backup-first helper to align diverged local `main` to `origin/main` (read-only by default) |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |
@@ -81,8 +82,9 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-preflight-strict-clean` | local validation for strict-clean preflight helper JSON/exit contract (clean pass + dirty fail) |
 | `mise run smoketest:bmad-reconcile-main-divergence` | local validation for patch-equivalent `main` divergence detection/reconcile contract |
 | `mise run smoketest:bmad-primary-recovery-check` | local validation for read-only primary checkout recovery diagnostics contract |
+| `mise run smoketest:bmad-align-main-with-backup` | local validation for backup-first diverged-main alignment helper contract |
 | `mise run smoketest:hermes-runtime-hygiene` | local validation for Hermes runtime ignore contract (runtime state ignored, skeleton trackable) |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/gh-readonly-status/preflight-strict-clean/reconcile-main-divergence/hermes-runtime-hygiene, fail-fast) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/repo-health-helper-availability/gh-readonly-status/preflight-strict-clean/reconcile-main-divergence/primary-recovery-check/align-main-with-backup/hermes-runtime-hygiene, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline
@@ -108,6 +110,7 @@ alongside each service, using Holyfields-generated publishers.
 - For non-mutating loop evidence on local drift state, use `mise run repo-health:drift`.
 - If `main` is `ahead` and `behind` with patch-equivalent divergence, use `mise run bmad:reconcile-main-divergence` to confirm and optionally apply safe local reconciliation.
 - If helper files are missing locally while `main` is diverged, run `mise run bmad:primary-recovery-check` then follow `ops/bmad/primary-checkout-recovery.md` before any destructive sync action.
+- For backup-first canonical alignment, use `mise run bmad:align-main-with-backup -- --repo <path>` (read-only) then rerun with `--apply` only after review.
 - `bmad:pr-merge-safe` now attempts safe post-merge reconciliation by default; use `--no-reconcile-main` only when you explicitly need to defer reconciliation.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.

--- a/_bmad_output/issue-174-execution.md
+++ b/_bmad_output/issue-174-execution.md
@@ -1,0 +1,27 @@
+# Issue 174 — execution closeout
+
+## Ticket
+- Issue: #174
+- Title: Add backup-first helper to align diverged primary main safely
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added `ops/bmad/align_main_with_backup.py` backup-first alignment helper (read-only default, guarded `--apply`).
+- Added deterministic smoke coverage `ops/smoketest/smoketest-bmad-align-main-with-backup.sh`.
+- Wired task + docs surfaces in `mise.toml`, `AGENTS.md`, and `ops/bmad/primary-checkout-recovery.md`.
+
+## Out of scope
+- Automatic trigger/execution against primary checkout without explicit operator `--apply` invocation.
+
+## Verification evidence
+- `bash ops/smoketest/smoketest-bmad-align-main-with-backup.sh` → PASS
+- `python3 -m py_compile ops/bmad/align_main_with_backup.py` → success
+- `python3 ops/bmad/align_main_with_backup.py --repo /home/delorenj/code/33GOD/bloodbank --timestamp 20260515T221000Z` → read-only plan output, `recommended_action=backup_then_reset_origin_main`
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/174
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Primary checkout drift currently reports `ahead 1, behind 6`; helper now provides deterministic backup/reset contract for safe canonical alignment.

--- a/mise.toml
+++ b/mise.toml
@@ -104,6 +104,10 @@ run = "python3 ops/bmad/reconcile_main_divergence.py"
 description = "Read-only diagnostics for recovering a diverged primary checkout when helper files are missing"
 run = "python3 ops/bmad/primary_recovery_check.py"
 
+[tasks."bmad:align-main-with-backup"]
+description = "Backup-first helper to align diverged local main to origin/main (read-only by default)"
+run = "python3 ops/bmad/align_main_with_backup.py"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"
@@ -196,13 +200,17 @@ run = "bash ops/smoketest/smoketest-bmad-reconcile-main-divergence.sh"
 description = "Local smoke test for read-only primary checkout recovery diagnostics helper"
 run = "bash ops/smoketest/smoketest-bmad-primary-recovery-check.sh"
 
+[tasks."smoketest:bmad-align-main-with-backup"]
+description = "Local smoke test for backup-first diverged-main alignment helper"
+run = "bash ops/smoketest/smoketest-bmad-align-main-with-backup.sh"
+
 [tasks."smoketest:hermes-runtime-hygiene"]
 description = "Local smoke test for Hermes runtime ignore/track contract"
 run = "bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-repo-health-helper-availability && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:hermes-runtime-hygiene"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-repo-health-helper-availability && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:bmad-align-main-with-backup && mise run smoketest:hermes-runtime-hygiene"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/align_main_with_backup.py
+++ b/ops/bmad/align_main_with_backup.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Backup-first alignment helper for diverged local main vs origin/main.
+
+Default mode is read-only planning output. Use --apply to create a backup branch,
+write a bundle artifact, then hard-reset local main to origin/main.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _run(repo: Path, *cmd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(repo), text=True, capture_output=True, check=False)
+
+
+def _branch(repo: Path) -> str:
+    cp = _run(repo, "git", "rev-parse", "--abbrev-ref", "HEAD")
+    return cp.stdout.strip() if cp.returncode == 0 else ""
+
+
+def _now_ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def evaluate(repo: Path, bundle_dir: Path, timestamp: str | None = None) -> dict[str, Any]:
+    ts = timestamp or _now_ts()
+    backup_branch = f"backup/main-divergence-{ts}"
+    bundle_path = bundle_dir / f"bloodbank-main-{ts}.bundle"
+
+    payload: dict[str, Any] = {
+        "ok": False,
+        "repo": str(repo),
+        "branch": _branch(repo),
+        "ahead": None,
+        "behind": None,
+        "patch_equivalent_divergence": False,
+        "backup_branch": backup_branch,
+        "bundle_path": str(bundle_path),
+        "backup_created": False,
+        "bundle_created": False,
+        "reset_applied": False,
+        "recommended_action": None,
+        "commands": [
+            f"git branch {backup_branch} main",
+            f"git bundle create {bundle_path} main {backup_branch}",
+            "git checkout main",
+            "git fetch origin main",
+            "git reset --hard origin/main",
+        ],
+        "errors": [],
+    }
+
+    _run(repo, "git", "fetch", "origin", "main")
+
+    counts = _run(repo, "git", "rev-list", "--left-right", "--count", "main...origin/main")
+    if counts.returncode != 0:
+        payload["errors"] = [counts.stderr.strip() or "rev-list failed"]
+        return payload
+
+    left, right = counts.stdout.strip().split()
+    ahead = int(left)
+    behind = int(right)
+    payload["ahead"] = ahead
+    payload["behind"] = behind
+
+    cherry = _run(repo, "git", "log", "--left-right", "--cherry-pick", "--oneline", "main...origin/main")
+    if cherry.returncode != 0:
+        payload["errors"] = [cherry.stderr.strip() or "cherry-pick log failed"]
+        return payload
+
+    payload["patch_equivalent_divergence"] = ahead > 0 and behind > 0 and cherry.stdout.strip() == ""
+
+    if ahead == 0 and behind == 0:
+        payload["ok"] = True
+        payload["recommended_action"] = "none"
+        return payload
+
+    payload["ok"] = True
+    payload["recommended_action"] = "backup_then_reset_origin_main"
+    return payload
+
+
+def apply(repo: Path, payload: dict[str, Any]) -> tuple[bool, str]:
+    if payload.get("branch") != "main":
+        return False, "apply requires current branch = main"
+
+    if payload.get("ahead") == 0 and payload.get("behind") == 0:
+        return True, "already_aligned"
+
+    backup_branch = str(payload["backup_branch"])
+    bundle_path = Path(str(payload["bundle_path"]))
+
+    cp = _run(repo, "git", "branch", backup_branch, "main")
+    if cp.returncode != 0:
+        return False, cp.stderr.strip() or "backup branch create failed"
+    payload["backup_created"] = True
+
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    cp = _run(repo, "git", "bundle", "create", str(bundle_path), "main", backup_branch)
+    if cp.returncode != 0:
+        return False, cp.stderr.strip() or "bundle create failed"
+    payload["bundle_created"] = True
+
+    cp = _run(repo, "git", "reset", "--hard", "origin/main")
+    if cp.returncode != 0:
+        return False, cp.stderr.strip() or "git reset --hard failed"
+    payload["reset_applied"] = True
+    return True, "applied"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backup-first alignment helper for diverged local main")
+    parser.add_argument("--repo", default=".", help="Repo root (default: .)")
+    parser.add_argument("--bundle-dir", default="/tmp", help="Bundle output directory (default: /tmp)")
+    parser.add_argument("--timestamp", default=None, help="Deterministic timestamp override (UTC format)")
+    parser.add_argument("--apply", action="store_true", help="Create backup+bundle and reset local main")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    payload = evaluate(repo, Path(args.bundle_dir), timestamp=args.timestamp)
+
+    if args.apply:
+        ok, msg = apply(repo, payload)
+        if not ok:
+            errs = payload.get("errors")
+            if isinstance(errs, list):
+                errs.append(msg)
+            else:
+                payload["errors"] = [msg]
+            print(json.dumps(payload, indent=2))
+            return 1
+
+        if msg == "applied":
+            refreshed = evaluate(repo, Path(args.bundle_dir), timestamp=args.timestamp)
+            refreshed["backup_branch"] = payload["backup_branch"]
+            refreshed["bundle_path"] = payload["bundle_path"]
+            refreshed["backup_created"] = payload["backup_created"]
+            refreshed["bundle_created"] = payload["bundle_created"]
+            refreshed["reset_applied"] = payload["reset_applied"]
+            payload = refreshed
+        else:
+            payload["reset_applied"] = False
+
+    print(json.dumps(payload, indent=2))
+    return 0 if payload.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/bmad/primary-checkout-recovery.md
+++ b/ops/bmad/primary-checkout-recovery.md
@@ -15,7 +15,21 @@ This emits:
 - `helper_on_origin_main`
 - `recommended_path`
 
-## 1) Safety anchor before any destructive action
+## 1) Preferred backup-first helper (recommended)
+
+Run helper in read-only mode first:
+
+```bash
+mise run bmad:align-main-with-backup -- --repo /path/to/primary/checkout
+```
+
+If output looks correct, run apply mode (creates backup branch + bundle + reset):
+
+```bash
+mise run bmad:align-main-with-backup -- --repo /path/to/primary/checkout --apply
+```
+
+## 1b) Manual safety anchor (fallback)
 
 ```bash
 cd /path/to/primary/checkout
@@ -56,9 +70,13 @@ python3 ops/bmad/reconcile_main_divergence.py --repo /path/to/primary/checkout -
 
 Use one of:
 - rebase/local-history repair path, or
-- backup then reset to canonical `origin/main`.
+- helper-driven backup + reset to canonical `origin/main`:
 
-This is a **manual decision point** and should be ticketed/evidenced.
+```bash
+mise run bmad:align-main-with-backup -- --repo /path/to/primary/checkout --apply
+```
+
+This remains a **manual decision point** and should be ticketed/evidenced.
 
 ## 3) Post-recovery verification
 

--- a/ops/smoketest/smoketest-bmad-align-main-with-backup.sh
+++ b/ops/smoketest/smoketest-bmad-align-main-with-backup.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Deterministic smoke test for align_main_with_backup helper.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+import subprocess
+
+import ops.bmad.align_main_with_backup as h
+
+orig_run = h._run
+orig_branch = h._branch
+
+try:
+    # Case 1: read-only evaluation yields backup/reset recommendation.
+    def fake_run_eval(_repo, *cmd):
+        if cmd[:3] == ("git", "rev-list", "--left-right"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="1 5\n", stderr="")
+        if cmd[:4] == ("git", "log", "--left-right", "--cherry-pick"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="< a\n> b\n", stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    h._run = fake_run_eval
+    h._branch = lambda _repo: "main"
+
+    payload = h.evaluate(h.Path("."), h.Path("/tmp"), timestamp="20260515T220000Z")
+    assert payload["ok"] is True, payload
+    assert payload["ahead"] == 1 and payload["behind"] == 5, payload
+    assert payload["recommended_action"] == "backup_then_reset_origin_main", payload
+    assert payload["backup_branch"] == "backup/main-divergence-20260515T220000Z", payload
+
+    # Case 2: apply requires branch=main.
+    h._branch = lambda _repo: "feature/test"
+    payload_non_main = h.evaluate(h.Path("."), h.Path("/tmp"), timestamp="20260515T220000Z")
+    ok, msg = h.apply(h.Path("."), payload_non_main)
+    assert ok is False and "branch = main" in msg, (ok, msg)
+
+    # Case 3: apply success path performs branch+bundle+reset.
+    calls = []
+
+    def fake_run_apply(_repo, *cmd):
+        calls.append(cmd)
+        if cmd[:3] == ("git", "rev-list", "--left-right"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="1 2\n", stderr="")
+        if cmd[:4] == ("git", "log", "--left-right", "--cherry-pick"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="< a\n> b\n", stderr="")
+        if cmd[:2] == ("git", "branch"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        if cmd[:3] == ("git", "bundle", "create"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        if cmd[:3] == ("git", "reset", "--hard"):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    h._run = fake_run_apply
+    h._branch = lambda _repo: "main"
+    payload_apply = h.evaluate(h.Path("."), h.Path("/tmp"), timestamp="20260515T220001Z")
+    ok, msg = h.apply(h.Path("."), payload_apply)
+    assert ok is True and msg == "applied", (ok, msg)
+    assert payload_apply["backup_created"] is True, payload_apply
+    assert payload_apply["bundle_created"] is True, payload_apply
+    assert payload_apply["reset_applied"] is True, payload_apply
+
+finally:
+    h._run = orig_run
+    h._branch = orig_branch
+PY
+
+echo "smoketest-bmad-align-main-with-backup: PASS"


### PR DESCRIPTION
## Summary
- add `ops/bmad/align_main_with_backup.py` backup-first helper for diverged `main`
  - read-only by default
  - `--apply` creates backup branch + bundle then resets `main` to `origin/main`
- add deterministic smoke test `smoketest-bmad-align-main-with-backup`
- wire task/docs updates across `mise.toml`, `AGENTS.md`, and `primary-checkout-recovery.md`
- include BMAD closeout artifact for #174

## Verification
- `bash ops/smoketest/smoketest-bmad-align-main-with-backup.sh`
- `python3 -m py_compile ops/bmad/align_main_with_backup.py`
- `python3 ops/bmad/align_main_with_backup.py --repo /home/delorenj/code/33GOD/bloodbank --timestamp 20260515T221000Z`

Closes #174
