### PR TITLE
feat: add recovery artifact cleanup helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run bmad:reconcile-main-divergence -- [--repo <path>] [--apply] [--limit <n>]` | detect/optionally reconcile patch-equivalent `main...origin/main` divergence with commit-side summaries |
 | `mise run bmad:primary-recovery-check -- [--repo <path>]` | read-only divergence diagnostics + helper-availability check for primary checkout recovery |
 | `mise run bmad:align-main-with-backup -- [--repo <path>] [--bundle-dir <path>] [--apply]` | backup-first helper to align diverged local `main` to `origin/main` (read-only by default) |
+| `mise run bmad:recovery-artifact-cleanup -- [--repo <path>] [--bundle-dir <path>] [--keep-branches <n>] [--keep-bundles <n>] [--apply]` | cleanup helper for post-recovery backup branches + bundle artifacts (dry-run default) |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |
@@ -83,8 +84,9 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run smoketest:bmad-reconcile-main-divergence` | local validation for patch-equivalent `main` divergence detection/reconcile contract |
 | `mise run smoketest:bmad-primary-recovery-check` | local validation for read-only primary checkout recovery diagnostics contract |
 | `mise run smoketest:bmad-align-main-with-backup` | local validation for backup-first diverged-main alignment helper contract |
+| `mise run smoketest:bmad-recovery-artifact-cleanup` | local validation for backup-branch + bundle cleanup helper contract |
 | `mise run smoketest:hermes-runtime-hygiene` | local validation for Hermes runtime ignore contract (runtime state ignored, skeleton trackable) |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/repo-health-helper-availability/gh-readonly-status/preflight-strict-clean/reconcile-main-divergence/primary-recovery-check/align-main-with-backup/hermes-runtime-hygiene, fail-fast) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/repo-health-helper-availability/gh-readonly-status/preflight-strict-clean/reconcile-main-divergence/primary-recovery-check/align-main-with-backup/recovery-artifact-cleanup/hermes-runtime-hygiene, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline
@@ -111,6 +113,7 @@ alongside each service, using Holyfields-generated publishers.
 - If `main` is `ahead` and `behind` with patch-equivalent divergence, use `mise run bmad:reconcile-main-divergence` to confirm and optionally apply safe local reconciliation.
 - If helper files are missing locally while `main` is diverged, run `mise run bmad:primary-recovery-check` then follow `ops/bmad/primary-checkout-recovery.md` before any destructive sync action.
 - For backup-first canonical alignment, use `mise run bmad:align-main-with-backup -- --repo <path>` (read-only) then rerun with `--apply` only after review.
+- After successful alignment verification window, run `mise run bmad:recovery-artifact-cleanup -- --repo <path>` (dry-run) before any cleanup apply.
 - `bmad:pr-merge-safe` now attempts safe post-merge reconciliation by default; use `--no-reconcile-main` only when you explicitly need to defer reconciliation.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.

--- a/_bmad_output/issue-177-execution.md
+++ b/_bmad_output/issue-177-execution.md
@@ -1,0 +1,27 @@
+# Issue 177 — execution closeout
+
+## Ticket
+- Issue: #177
+- Title: Add lifecycle hygiene for backup branches and recovery bundles
+- Owner: hermes (pilot)
+
+## Scope completed
+- Added helper `ops/bmad/recovery_artifact_cleanup.py` for backup-branch and bundle cleanup (dry-run default, guarded apply mode).
+- Added deterministic smoke test `ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh`.
+- Wired task + docs updates across `mise.toml`, `AGENTS.md`, and `ops/bmad/primary-checkout-recovery.md`.
+
+## Out of scope
+- Automatic execution of cleanup apply mode in operator loop (remains explicit/manual guard).
+
+## Verification evidence
+- `bash ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh` → PASS
+- `python3 -m py_compile ops/bmad/recovery_artifact_cleanup.py` → success
+- `python3 ops/bmad/recovery_artifact_cleanup.py --repo /home/delorenj/code/33GOD/bloodbank --bundle-dir /tmp --keep-branches 1 --keep-bundles 1` → dry-run JSON plan rendered
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/177
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Current state keeps one active recovery branch + one bundle; helper now provides deterministic retirement path when retention window expires.

--- a/mise.toml
+++ b/mise.toml
@@ -108,6 +108,10 @@ run = "python3 ops/bmad/primary_recovery_check.py"
 description = "Backup-first helper to align diverged local main to origin/main (read-only by default)"
 run = "python3 ops/bmad/align_main_with_backup.py"
 
+[tasks."bmad:recovery-artifact-cleanup"]
+description = "Cleanup helper for backup branches + recovery bundles (dry-run by default)"
+run = "python3 ops/bmad/recovery_artifact_cleanup.py"
+
 [tasks.bootstrap]
 description = "Pre-boot file-presence validator"
 run = "bash ops/bootstrap/check-platform.sh"
@@ -204,13 +208,17 @@ run = "bash ops/smoketest/smoketest-bmad-primary-recovery-check.sh"
 description = "Local smoke test for backup-first diverged-main alignment helper"
 run = "bash ops/smoketest/smoketest-bmad-align-main-with-backup.sh"
 
+[tasks."smoketest:bmad-recovery-artifact-cleanup"]
+description = "Local smoke test for backup-branch and bundle cleanup helper"
+run = "bash ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh"
+
 [tasks."smoketest:hermes-runtime-hygiene"]
 description = "Local smoke test for Hermes runtime ignore/track contract"
 run = "bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-repo-health-helper-availability && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:bmad-align-main-with-backup && mise run smoketest:hermes-runtime-hygiene"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-repo-health-helper-availability && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:bmad-align-main-with-backup && mise run smoketest:bmad-recovery-artifact-cleanup && mise run smoketest:hermes-runtime-hygiene"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/primary-checkout-recovery.md
+++ b/ops/bmad/primary-checkout-recovery.md
@@ -89,3 +89,17 @@ Target state:
 - `main...origin/main` (no ahead/behind)
 - `worktree_dirty=false`
 - helper files available locally.
+
+## 4) Post-recovery artifact hygiene
+
+Preview cleanup plan first:
+
+```bash
+mise run bmad:recovery-artifact-cleanup -- --repo /path/to/primary/checkout
+```
+
+Apply cleanup when ready (example keeps latest 1 branch + 1 bundle):
+
+```bash
+mise run bmad:recovery-artifact-cleanup -- --repo /path/to/primary/checkout --keep-branches 1 --keep-bundles 1 --apply
+```

--- a/ops/bmad/recovery_artifact_cleanup.py
+++ b/ops/bmad/recovery_artifact_cleanup.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Cleanup helper for post-recovery backup branches and bundle artifacts.
+
+Default mode is dry-run preview. Use --apply to execute deletion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+BACKUP_PREFIX = "backup/main-divergence-"
+BUNDLE_GLOB = "bloodbank-main-*.bundle"
+
+
+def _run(repo: Path, *cmd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(repo), text=True, capture_output=True, check=False)
+
+
+def _list_backup_branches(repo: Path) -> list[str]:
+    cp = _run(repo, "git", "for-each-ref", "--format=%(refname:short)", f"refs/heads/{BACKUP_PREFIX}*")
+    if cp.returncode != 0 or not cp.stdout.strip():
+        return []
+    return sorted([line.strip() for line in cp.stdout.splitlines() if line.strip()])
+
+
+def _list_bundle_paths(bundle_dir: Path) -> list[Path]:
+    if not bundle_dir.exists():
+        return []
+    return sorted(bundle_dir.glob(BUNDLE_GLOB))
+
+
+def _plan_keep_remove(items: list[Any], keep: int) -> tuple[list[Any], list[Any]]:
+    if keep <= 0:
+        return [], items
+    if len(items) <= keep:
+        return items, []
+    split = len(items) - keep
+    return items[split:], items[:split]
+
+
+def _delete_branch(repo: Path, branch: str) -> tuple[bool, str]:
+    cp = _run(repo, "git", "branch", "-D", branch)
+    if cp.returncode != 0:
+        return False, cp.stderr.strip() or "branch delete failed"
+    return True, "deleted"
+
+
+def _delete_file(path: Path) -> tuple[bool, str]:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        return False, str(exc)
+    return True, "deleted"
+
+
+def evaluate(repo: Path, bundle_dir: Path, keep_branches: int, keep_bundles: int, apply: bool) -> dict[str, Any]:
+    branches = _list_backup_branches(repo)
+    bundles = _list_bundle_paths(bundle_dir)
+
+    keep_branch, remove_branch = _plan_keep_remove(branches, keep_branches)
+    keep_bundle, remove_bundle = _plan_keep_remove(bundles, keep_bundles)
+
+    payload: dict[str, Any] = {
+        "ok": True,
+        "repo": str(repo),
+        "bundle_dir": str(bundle_dir),
+        "dry_run": not apply,
+        "keep_branches": keep_branches,
+        "keep_bundles": keep_bundles,
+        "backup_branches_total": len(branches),
+        "bundle_files_total": len(bundles),
+        "backup_branches_kept": keep_branch,
+        "backup_branches_remove": remove_branch,
+        "bundle_files_kept": [str(p) for p in keep_bundle],
+        "bundle_files_remove": [str(p) for p in remove_bundle],
+        "backup_branches_removed": [],
+        "bundle_files_removed": [],
+        "errors": [],
+    }
+
+    if not apply:
+        return payload
+
+    for br in remove_branch:
+        ok, msg = _delete_branch(repo, br)
+        if ok:
+            payload["backup_branches_removed"].append(br)
+        else:
+            payload["ok"] = False
+            payload["errors"].append(f"branch:{br}: {msg}")
+
+    for fp in remove_bundle:
+        ok, msg = _delete_file(fp)
+        if ok:
+            payload["bundle_files_removed"].append(str(fp))
+        else:
+            payload["ok"] = False
+            payload["errors"].append(f"bundle:{fp}: {msg}")
+
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Cleanup backup branches and bundle artifacts")
+    parser.add_argument("--repo", default=".", help="Repo root (default: .)")
+    parser.add_argument("--bundle-dir", default="/tmp", help="Bundle directory (default: /tmp)")
+    parser.add_argument("--keep-branches", type=int, default=1, help="Keep latest N backup branches (default: 1)")
+    parser.add_argument("--keep-bundles", type=int, default=1, help="Keep latest N bundle files (default: 1)")
+    parser.add_argument("--apply", action="store_true", help="Execute deletion plan")
+    args = parser.parse_args()
+
+    keep_branches = max(0, args.keep_branches)
+    keep_bundles = max(0, args.keep_bundles)
+
+    payload = evaluate(
+        Path(args.repo).resolve(),
+        Path(args.bundle_dir).resolve(),
+        keep_branches,
+        keep_bundles,
+        args.apply,
+    )
+    print(json.dumps(payload, indent=2))
+    return 0 if payload.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh
+++ b/ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Deterministic smoke test for recovery_artifact_cleanup helper.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+from pathlib import Path
+
+import ops.bmad.recovery_artifact_cleanup as h
+
+orig_list_branches = h._list_backup_branches
+orig_list_bundles = h._list_bundle_paths
+orig_delete_branch = h._delete_branch
+orig_delete_file = h._delete_file
+
+try:
+    branches = [
+        "backup/main-divergence-20260515T010000Z",
+        "backup/main-divergence-20260515T020000Z",
+        "backup/main-divergence-20260515T030000Z",
+    ]
+    bundles = [
+        Path("/tmp/bloodbank-main-20260515T010000Z.bundle"),
+        Path("/tmp/bloodbank-main-20260515T020000Z.bundle"),
+    ]
+
+    h._list_backup_branches = lambda _repo: list(branches)
+    h._list_bundle_paths = lambda _bundle_dir: list(bundles)
+
+    # Case 1: dry-run planning
+    payload = h.evaluate(Path("."), Path("/tmp"), keep_branches=1, keep_bundles=1, apply=False)
+    assert payload["dry_run"] is True, payload
+    assert payload["backup_branches_kept"] == [branches[-1]], payload
+    assert payload["backup_branches_remove"] == branches[:-1], payload
+    assert payload["bundle_files_kept"] == [str(bundles[-1])], payload
+    assert payload["bundle_files_remove"] == [str(bundles[0])], payload
+
+    # Case 2: apply execution
+    deleted_branches = []
+    deleted_files = []
+
+    h._delete_branch = lambda _repo, br: (deleted_branches.append(br) or True, "deleted")
+    h._delete_file = lambda fp: (deleted_files.append(str(fp)) or True, "deleted")
+
+    payload_apply = h.evaluate(Path("."), Path("/tmp"), keep_branches=1, keep_bundles=1, apply=True)
+    assert payload_apply["dry_run"] is False, payload_apply
+    assert sorted(deleted_branches) == sorted(branches[:-1]), deleted_branches
+    assert deleted_files == [str(bundles[0])], deleted_files
+    assert payload_apply["ok"] is True, payload_apply
+
+finally:
+    h._list_backup_branches = orig_list_branches
+    h._list_bundle_paths = orig_list_bundles
+    h._delete_branch = orig_delete_branch
+    h._delete_file = orig_delete_file
+PY
+
+echo "smoketest-bmad-recovery-artifact-cleanup: PASS"


### PR DESCRIPTION
## Summary
- add `ops/bmad/recovery_artifact_cleanup.py` to manage post-recovery backup branches + bundle artifacts
  - dry-run by default
  - guarded `--apply` mode
  - configurable `--keep-branches` / `--keep-bundles`
- add deterministic smoke test `smoketest-bmad-recovery-artifact-cleanup`
- wire task/docs updates in `mise.toml`, `AGENTS.md`, and `primary-checkout-recovery.md`
- include BMAD closeout artifact for #177

## Verification
- `bash ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh`
- `python3 -m py_compile ops/bmad/recovery_artifact_cleanup.py`
- `python3 ops/bmad/recovery_artifact_cleanup.py --repo /home/delorenj/code/33GOD/bloodbank --bundle-dir /tmp --keep-branches 1 --keep-bundles 1`

Closes #177
