### PR TITLE
feat: add age-gated retention to recovery cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ alongside each service, using Holyfields-generated publishers.
 | `mise run bmad:reconcile-main-divergence -- [--repo <path>] [--apply] [--limit <n>]` | detect/optionally reconcile patch-equivalent `main...origin/main` divergence with commit-side summaries |
 | `mise run bmad:primary-recovery-check -- [--repo <path>]` | read-only divergence diagnostics + helper-availability check for primary checkout recovery |
 | `mise run bmad:align-main-with-backup -- [--repo <path>] [--bundle-dir <path>] [--apply]` | backup-first helper to align diverged local `main` to `origin/main` (read-only by default) |
-| `mise run bmad:recovery-artifact-cleanup -- [--repo <path>] [--bundle-dir <path>] [--keep-branches <n>] [--keep-bundles <n>] [--apply]` | cleanup helper for post-recovery backup branches + bundle artifacts (dry-run default) |
+| `mise run bmad:recovery-artifact-cleanup -- [--repo <path>] [--bundle-dir <path>] [--keep-branches <n>] [--keep-bundles <n>] [--min-bundle-age-hours <h>] [--apply]` | cleanup helper for post-recovery backup branches + bundle artifacts (dry-run default, optional age gate) |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
 | `mise run smoketest:command` | NATS-direct command + reply round-trip      |
@@ -113,7 +113,7 @@ alongside each service, using Holyfields-generated publishers.
 - If `main` is `ahead` and `behind` with patch-equivalent divergence, use `mise run bmad:reconcile-main-divergence` to confirm and optionally apply safe local reconciliation.
 - If helper files are missing locally while `main` is diverged, run `mise run bmad:primary-recovery-check` then follow `ops/bmad/primary-checkout-recovery.md` before any destructive sync action.
 - For backup-first canonical alignment, use `mise run bmad:align-main-with-backup -- --repo <path>` (read-only) then rerun with `--apply` only after review.
-- After successful alignment verification window, run `mise run bmad:recovery-artifact-cleanup -- --repo <path>` (dry-run) before any cleanup apply.
+- After successful alignment verification window, run `mise run bmad:recovery-artifact-cleanup -- --repo <path>` (dry-run) before any cleanup apply; use `--min-bundle-age-hours` to protect fresh bundles.
 - `bmad:pr-merge-safe` now attempts safe post-merge reconciliation by default; use `--no-reconcile-main` only when you explicitly need to defer reconciliation.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.

--- a/_bmad_output/issue-180-execution.md
+++ b/_bmad_output/issue-180-execution.md
@@ -1,0 +1,27 @@
+# Issue 180 — execution closeout
+
+## Ticket
+- Issue: #180
+- Title: Add age-based retention policy for recovery bundle cleanup
+- Owner: hermes (pilot)
+
+## Scope completed
+- Extended `ops/bmad/recovery_artifact_cleanup.py` with `--min-bundle-age-hours` age gate for bundle deletion.
+- Added JSON age metadata fields (`bundle_file_age_hours`, `bundle_files_skip_too_young`, `bundle_files_remove_age_eligible`).
+- Updated deterministic smoke coverage and operator docs/task descriptions (`AGENTS.md`, `mise.toml`, `primary-checkout-recovery.md`).
+
+## Out of scope
+- Automated timed execution; cleanup apply remains explicit/manual.
+
+## Verification evidence
+- `bash ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh` → PASS
+- `python3 -m py_compile ops/bmad/recovery_artifact_cleanup.py` → success
+- `python3 ops/bmad/recovery_artifact_cleanup.py --repo /home/delorenj/code/33GOD/bloodbank --bundle-dir /tmp --keep-branches 0 --keep-bundles 0 --min-bundle-age-hours 24` → dry-run output shows young bundle skipped by age gate
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/180
+- PR: <url>
+- Follow-up tickets: none
+
+## Notes
+- Current fallback bundle (~1.3h old) is correctly protected by a 24h gate in dry-run output.

--- a/mise.toml
+++ b/mise.toml
@@ -109,7 +109,7 @@ description = "Backup-first helper to align diverged local main to origin/main (
 run = "python3 ops/bmad/align_main_with_backup.py"
 
 [tasks."bmad:recovery-artifact-cleanup"]
-description = "Cleanup helper for backup branches + recovery bundles (dry-run by default)"
+description = "Cleanup helper for backup branches + recovery bundles with optional bundle-age gate (dry-run default)"
 run = "python3 ops/bmad/recovery_artifact_cleanup.py"
 
 [tasks.bootstrap]

--- a/ops/bmad/primary-checkout-recovery.md
+++ b/ops/bmad/primary-checkout-recovery.md
@@ -98,8 +98,8 @@ Preview cleanup plan first:
 mise run bmad:recovery-artifact-cleanup -- --repo /path/to/primary/checkout
 ```
 
-Apply cleanup when ready (example keeps latest 1 branch + 1 bundle):
+Apply cleanup when ready (example keeps latest 1 branch + 1 bundle and only prunes bundles older than 24h):
 
 ```bash
-mise run bmad:recovery-artifact-cleanup -- --repo /path/to/primary/checkout --keep-branches 1 --keep-bundles 1 --apply
+mise run bmad:recovery-artifact-cleanup -- --repo /path/to/primary/checkout --keep-branches 1 --keep-bundles 1 --min-bundle-age-hours 24 --apply
 ```

--- a/ops/bmad/recovery_artifact_cleanup.py
+++ b/ops/bmad/recovery_artifact_cleanup.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
@@ -58,12 +59,31 @@ def _delete_file(path: Path) -> tuple[bool, str]:
     return True, "deleted"
 
 
-def evaluate(repo: Path, bundle_dir: Path, keep_branches: int, keep_bundles: int, apply: bool) -> dict[str, Any]:
+def _bundle_age_hours(path: Path, now_epoch: float) -> float:
+    st = path.stat()
+    return max(0.0, (now_epoch - st.st_mtime) / 3600.0)
+
+
+def evaluate(
+    repo: Path,
+    bundle_dir: Path,
+    keep_branches: int,
+    keep_bundles: int,
+    min_bundle_age_hours: float,
+    apply: bool,
+    now_epoch: float | None = None,
+) -> dict[str, Any]:
+    now = time.time() if now_epoch is None else now_epoch
+
     branches = _list_backup_branches(repo)
     bundles = _list_bundle_paths(bundle_dir)
 
     keep_branch, remove_branch = _plan_keep_remove(branches, keep_branches)
     keep_bundle, remove_bundle = _plan_keep_remove(bundles, keep_bundles)
+
+    bundle_ages = {str(p): round(_bundle_age_hours(p, now), 3) for p in bundles}
+    too_young = [p for p in remove_bundle if bundle_ages.get(str(p), 0.0) < min_bundle_age_hours]
+    age_eligible_remove_bundle = [p for p in remove_bundle if p not in too_young]
 
     payload: dict[str, Any] = {
         "ok": True,
@@ -72,12 +92,16 @@ def evaluate(repo: Path, bundle_dir: Path, keep_branches: int, keep_bundles: int
         "dry_run": not apply,
         "keep_branches": keep_branches,
         "keep_bundles": keep_bundles,
+        "min_bundle_age_hours": min_bundle_age_hours,
         "backup_branches_total": len(branches),
         "bundle_files_total": len(bundles),
         "backup_branches_kept": keep_branch,
         "backup_branches_remove": remove_branch,
         "bundle_files_kept": [str(p) for p in keep_bundle],
         "bundle_files_remove": [str(p) for p in remove_bundle],
+        "bundle_file_age_hours": bundle_ages,
+        "bundle_files_skip_too_young": [str(p) for p in too_young],
+        "bundle_files_remove_age_eligible": [str(p) for p in age_eligible_remove_bundle],
         "backup_branches_removed": [],
         "bundle_files_removed": [],
         "errors": [],
@@ -94,7 +118,7 @@ def evaluate(repo: Path, bundle_dir: Path, keep_branches: int, keep_bundles: int
             payload["ok"] = False
             payload["errors"].append(f"branch:{br}: {msg}")
 
-    for fp in remove_bundle:
+    for fp in age_eligible_remove_bundle:
         ok, msg = _delete_file(fp)
         if ok:
             payload["bundle_files_removed"].append(str(fp))
@@ -111,6 +135,12 @@ def main() -> int:
     parser.add_argument("--bundle-dir", default="/tmp", help="Bundle directory (default: /tmp)")
     parser.add_argument("--keep-branches", type=int, default=1, help="Keep latest N backup branches (default: 1)")
     parser.add_argument("--keep-bundles", type=int, default=1, help="Keep latest N bundle files (default: 1)")
+    parser.add_argument(
+        "--min-bundle-age-hours",
+        type=float,
+        default=0.0,
+        help="Only delete candidate bundles at/above this age in hours (default: 0)",
+    )
     parser.add_argument("--apply", action="store_true", help="Execute deletion plan")
     args = parser.parse_args()
 
@@ -122,6 +152,7 @@ def main() -> int:
         Path(args.bundle_dir).resolve(),
         keep_branches,
         keep_bundles,
+        max(0.0, args.min_bundle_age_hours),
         args.apply,
     )
     print(json.dumps(payload, indent=2))

--- a/ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh
+++ b/ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh
@@ -15,6 +15,7 @@ orig_list_branches = h._list_backup_branches
 orig_list_bundles = h._list_bundle_paths
 orig_delete_branch = h._delete_branch
 orig_delete_file = h._delete_file
+orig_bundle_age = h._bundle_age_hours
 
 try:
     branches = [
@@ -29,26 +30,44 @@ try:
 
     h._list_backup_branches = lambda _repo: list(branches)
     h._list_bundle_paths = lambda _bundle_dir: list(bundles)
+    h._bundle_age_hours = lambda p, _now: 0.5 if p == bundles[0] else 48.0
 
-    # Case 1: dry-run planning
-    payload = h.evaluate(Path("."), Path("/tmp"), keep_branches=1, keep_bundles=1, apply=False)
+    # Case 1: dry-run planning with age threshold (young bundle excluded from apply-set)
+    payload = h.evaluate(
+        Path("."),
+        Path("/tmp"),
+        keep_branches=1,
+        keep_bundles=0,
+        min_bundle_age_hours=1.0,
+        apply=False,
+        now_epoch=0,
+    )
     assert payload["dry_run"] is True, payload
     assert payload["backup_branches_kept"] == [branches[-1]], payload
     assert payload["backup_branches_remove"] == branches[:-1], payload
-    assert payload["bundle_files_kept"] == [str(bundles[-1])], payload
-    assert payload["bundle_files_remove"] == [str(bundles[0])], payload
+    assert payload["bundle_files_remove"] == [str(bundles[0]), str(bundles[1])], payload
+    assert payload["bundle_files_skip_too_young"] == [str(bundles[0])], payload
+    assert payload["bundle_files_remove_age_eligible"] == [str(bundles[1])], payload
 
-    # Case 2: apply execution
+    # Case 2: apply execution obeys age threshold
     deleted_branches = []
     deleted_files = []
 
     h._delete_branch = lambda _repo, br: (deleted_branches.append(br) or True, "deleted")
     h._delete_file = lambda fp: (deleted_files.append(str(fp)) or True, "deleted")
 
-    payload_apply = h.evaluate(Path("."), Path("/tmp"), keep_branches=1, keep_bundles=1, apply=True)
+    payload_apply = h.evaluate(
+        Path("."),
+        Path("/tmp"),
+        keep_branches=1,
+        keep_bundles=0,
+        min_bundle_age_hours=1.0,
+        apply=True,
+        now_epoch=0,
+    )
     assert payload_apply["dry_run"] is False, payload_apply
     assert sorted(deleted_branches) == sorted(branches[:-1]), deleted_branches
-    assert deleted_files == [str(bundles[0])], deleted_files
+    assert deleted_files == [str(bundles[1])], deleted_files
     assert payload_apply["ok"] is True, payload_apply
 
 finally:
@@ -56,6 +75,7 @@ finally:
     h._list_bundle_paths = orig_list_bundles
     h._delete_branch = orig_delete_branch
     h._delete_file = orig_delete_file
+    h._bundle_age_hours = orig_bundle_age
 PY
 
 echo "smoketest-bmad-recovery-artifact-cleanup: PASS"


### PR DESCRIPTION
## Summary
- extend `ops/bmad/recovery_artifact_cleanup.py` with age-gated bundle retention:
  - add `--min-bundle-age-hours`
  - keep dry-run default and explicit apply
  - emit bundle age metadata + skipped-by-age candidates in JSON output
- update deterministic smoke test coverage for age threshold behavior
- update task/docs wiring in `mise.toml`, `AGENTS.md`, and `ops/bmad/primary-checkout-recovery.md`
- include BMAD closeout artifact for #180

## Verification
- `bash ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh`
- `python3 -m py_compile ops/bmad/recovery_artifact_cleanup.py`
- `python3 ops/bmad/recovery_artifact_cleanup.py --repo /home/delorenj/code/33GOD/bloodbank --bundle-dir /tmp --keep-branches 0 --keep-bundles 0 --min-bundle-age-hours 24`

Closes #180
