### PR TITLE
fix(bmad): ignore hermes runtime submodule scratch for strict-clean gate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "agents/hermes/pm/runtime"]
 	path = agents/hermes/pm/runtime
 	url = git@github.com:delorenj/agent-hm-bloodbank-pm.git
+	ignore = untracked

--- a/_bmad_output/issue-189-execution.md
+++ b/_bmad_output/issue-189-execution.md
@@ -1,0 +1,25 @@
+# Issue 189 — execution closeout
+
+## Ticket
+- Issue: #189
+- Title: BMAD: unblock pilot strict-clean gate from Hermes runtime submodule artifacts
+- Owner: hermes
+
+## Scope completed
+- Set `ignore = untracked` for `agents/hermes/pm/runtime` in `.gitmodules` so expected runtime scratch does not dirty parent checkout.
+- Extended `ops/smoketest/smoketest-hermes-runtime-hygiene.sh` to assert the `pm/runtime` submodule ignore contract.
+
+## Out of scope
+- Any changes inside the `agents/hermes/pm/runtime` submodule repository itself.
+
+## Verification evidence
+- `mise run smoketest:hermes-runtime-hygiene` → `PASS`.
+- `git status --short --branch` (before staging) → no lingering `? agents/hermes/pm/runtime` dirty marker from runtime scratch.
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/189
+- PR: pending
+- Follow-up tickets: none
+
+## Notes
+- Remaining parent checkout dirtiness is only from intentional tracked edits for this ticket.

--- a/ops/smoketest/smoketest-hermes-runtime-hygiene.sh
+++ b/ops/smoketest/smoketest-hermes-runtime-hygiene.sh
@@ -31,4 +31,10 @@ if git check-ignore -q "agents/hermes/README.md"; then
   exit 1
 fi
 
+pm_runtime_ignore="$(git config -f .gitmodules --get submodule.agents/hermes/pm/runtime.ignore || true)"
+if [[ "$pm_runtime_ignore" != "untracked" ]]; then
+  echo "agents/hermes/pm/runtime submodule must set ignore=untracked in .gitmodules" >&2
+  exit 1
+fi
+
 echo "smoketest-hermes-runtime-hygiene: PASS"


### PR DESCRIPTION
## Summary
- set `ignore = untracked` for `agents/hermes/pm/runtime` in `.gitmodules`
- extend Hermes runtime hygiene smoketest to enforce this submodule ignore contract
- add BMAD execution artifact for issue #189

## Verification
- `mise run smoketest:hermes-runtime-hygiene`
- `mise run repo-health:pilot-step`

Closes #189
