### PR TITLE
fix(repo-health): surface submodule gitlink drift diagnostics

### DIFF
--- a/_bmad_output/issue-191-execution.md
+++ b/_bmad_output/issue-191-execution.md
@@ -1,0 +1,27 @@
+# Issue 191 — execution closeout
+
+## Ticket
+- Issue: #191
+- Title: BMAD: handle Hermes runtime submodule gitlink drift in pilot strict-clean loop
+- Owner: hermes
+
+## Scope completed
+- Added `submodule_gitlink_drifts` diagnostics to `cli/bb.py repo-health` by parsing `git submodule status --recursive` (`+` marker) and enriching with recorded gitlink commit from `git ls-tree HEAD <path>`.
+- Added text-output rendering for drift count/details so strict-clean logs explain exact submodule gitlink mismatch paths/commits.
+- Extended deterministic smoke test `ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh` to cover drift detection contract in both JSON and text output.
+
+## Out of scope
+- Automatic submodule reconcile/mutation behavior.
+
+## Verification evidence
+- `python3 -m py_compile cli/bb.py` → success.
+- `bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh` → `PASS`.
+- `bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh` → `PASS`.
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/191
+- PR: pending
+- Follow-up tickets: none
+
+## Notes
+- In this patch, submodule drift is surfaced as explicit diagnostics plus a warning entry in `errors` when present.

--- a/cli/bb.py
+++ b/cli/bb.py
@@ -280,6 +280,49 @@ def _git_ref_path_exists(root: Path, ref: str, rel_path: str) -> bool:
     return rc == 0
 
 
+def _collect_submodule_gitlink_drifts(root: Path) -> tuple[list[dict[str, str]], str | None]:
+    """Return gitlink drift entries for submodules (marker '+' in status output)."""
+    rc, out, err = _run(root, "git", "submodule", "status", "--recursive")
+    if rc != 0:
+        return [], f"submodule_status: ERROR ({err or 'git submodule status failed'})"
+
+    drifts: list[dict[str, str]] = []
+    for raw in out.splitlines():
+        line = raw.rstrip()
+        if not line:
+            continue
+        marker = line[0]
+        if marker != "+":
+            continue
+
+        payload = line[1:].strip().split()
+        if len(payload) < 2:
+            continue
+
+        current_commit = payload[0]
+        path = payload[1]
+        detail = " ".join(payload[2:]).strip()
+
+        recorded_commit = ""
+        rc_tree, tree_out, _ = _run(root, "git", "ls-tree", "HEAD", path)
+        if rc_tree == 0 and tree_out:
+            # ls-tree format: <mode> <type> <object>\t<path>
+            tree_parts = tree_out.split()
+            if len(tree_parts) >= 3:
+                recorded_commit = tree_parts[2]
+
+        drifts.append(
+            {
+                "path": path,
+                "recorded_commit": recorded_commit,
+                "current_commit": current_commit,
+                "detail": detail,
+            }
+        )
+
+    return drifts, None
+
+
 def cmd_repo_health(args: argparse.Namespace) -> int:
     """Print a concise repo/ticket/PR/check snapshot for BMAD evidence."""
     root = bloodbank_root()
@@ -287,6 +330,7 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
     snapshot: dict[str, object] = {
         "git_status": None,
         "worktree_dirty": None,
+        "submodule_gitlink_drifts": [],
         "helper_local_exists": None,
         "helper_on_origin_main": None,
         "issues_open": [],
@@ -319,6 +363,21 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
     git_line = git_lines[0] if git_lines else "<no status output>"
     snapshot["git_status"] = git_line
     snapshot["worktree_dirty"] = len(git_lines) > 1
+
+    drifts, submodule_err = _collect_submodule_gitlink_drifts(root)
+    snapshot["submodule_gitlink_drifts"] = drifts
+    if submodule_err:
+        cast_errors = snapshot["errors"]
+        assert isinstance(cast_errors, list)
+        cast_errors.append(submodule_err)
+
+    if drifts:
+        cast_errors = snapshot["errors"]
+        assert isinstance(cast_errors, list)
+        cast_errors.append(
+            "submodule_gitlink_drifts: WARN (submodule commit differs from superproject gitlink)"
+        )
+
     helper_rel = "ops/bmad/reconcile_main_divergence.py"
     snapshot["helper_local_exists"] = (root / helper_rel).is_file()
     snapshot["helper_on_origin_main"] = _git_ref_path_exists(root, "origin/main", helper_rel)
@@ -413,6 +472,17 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
         lines_out: list[str] = []
         lines_out.append(f"git_status: {snapshot['git_status']}")
         lines_out.append(f"worktree_dirty: {str(snapshot['worktree_dirty']).lower()}")
+
+        drifts_out = snapshot["submodule_gitlink_drifts"]
+        assert isinstance(drifts_out, list)
+        lines_out.append(f"submodule_gitlink_drifts: {len(drifts_out)}")
+        for drift in drifts_out:
+            lines_out.append(
+                "- submodule "
+                f"{drift['path']}: recorded={drift.get('recorded_commit', '')} "
+                f"current={drift.get('current_commit', '')}"
+            )
+
         lines_out.append(
             "helper_local_exists: "
             f"{str(snapshot['helper_local_exists']).lower()}"

--- a/ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh
+++ b/ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh
@@ -23,6 +23,18 @@ try:
     def fake_run(_root, *argv):
         if argv[:3] == ("git", "status", "--short"):
             return (0, "## main...origin/main [ahead 1, behind 1]", "")
+        if argv[:4] == ("git", "submodule", "status", "--recursive"):
+            return (
+                0,
+                "+2b1061b012511ad46d7449ab0ac82f4fb595f135 agents/hermes/pm/runtime (heads/main)",
+                "",
+            )
+        if argv[:3] == ("git", "ls-tree", "HEAD"):
+            return (
+                0,
+                "160000 commit 65a0c089c3e1d10ee6a722bef076ee9a0646ab63\tagents/hermes/pm/runtime",
+                "",
+            )
         if argv[:4] == ("git", "cat-file", "-e", "origin/main:ops/bmad/reconcile_main_divergence.py"):
             return (0, "", "")
         if argv[:3] == ("gh", "issue", "list"):
@@ -34,18 +46,31 @@ try:
     bb.bloodbank_root = fake_root
     bb._run = fake_run
 
-    args = Namespace(limit=5, json_output=True, out_path=None, require_clean_worktree=False)
+    args = Namespace(
+        limit=5,
+        json_output=True,
+        out_path="/tmp/repo-health-helper-smoke.json",
+        require_clean_worktree=False,
+    )
     rc = bb.cmd_repo_health(args)
-    assert rc == 0, rc
+    assert rc == 1, rc  # drift warning is emitted as non-zero evidence signal
+
+    payload = json.loads(Path("/tmp/repo-health-helper-smoke.json").read_text(encoding="utf-8"))
+    drifts = payload.get("submodule_gitlink_drifts", [])
+    assert len(drifts) == 1, payload
+    assert drifts[0]["path"] == "agents/hermes/pm/runtime", payload
+    assert drifts[0]["recorded_commit"] == "65a0c089c3e1d10ee6a722bef076ee9a0646ab63", payload
+    assert drifts[0]["current_commit"] == "2b1061b012511ad46d7449ab0ac82f4fb595f135", payload
 
     # Re-run and capture rendered text path for non-json fields
     args = Namespace(limit=5, json_output=False, out_path="/tmp/repo-health-helper-smoke.txt", require_clean_worktree=False)
     rc = bb.cmd_repo_health(args)
-    assert rc == 0, rc
+    assert rc == 1, rc
 
     txt = Path("/tmp/repo-health-helper-smoke.txt").read_text(encoding="utf-8")
     assert "helper_local_exists:" in txt, txt
     assert "helper_on_origin_main: true" in txt, txt
+    assert "submodule_gitlink_drifts: 1" in txt, txt
 
 finally:
     bb._run = orig_run


### PR DESCRIPTION
## Summary
- add explicit `submodule_gitlink_drifts` diagnostics to `bb repo-health`
- include drift details in text-mode output (path + recorded/current commit)
- extend deterministic smoketest to lock drift diagnostics contract
- add BMAD execution artifact for issue #191

## Verification
- `python3 -m py_compile cli/bb.py`
- `bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh`
- `bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh`

Closes #191
