### PR TITLE
fix(repo-health): keep submodule drift as warning-level signal

### DIFF
--- a/_bmad_output/issue-193-execution.md
+++ b/_bmad_output/issue-193-execution.md
@@ -1,0 +1,27 @@
+# Issue 193 — execution closeout
+
+## Ticket
+- Issue: #193
+- Title: BMAD: fix repo-health exit-code regression from submodule drift warnings
+- Owner: hermes
+
+## Scope completed
+- Changed `cli/bb.py repo-health` to classify submodule drift notices as `warnings` instead of `errors`.
+- Preserved drift diagnostics (`submodule_gitlink_drifts`) in JSON and text output while keeping exit code reserved for hard failures.
+- Updated deterministic smoke coverage in `ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh` to enforce the non-failing warning contract.
+
+## Out of scope
+- Automatic submodule drift reconciliation/mutation logic.
+
+## Verification evidence
+- `python3 -m py_compile cli/bb.py` → success.
+- `bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh` → `PASS`.
+- `bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh` → `PASS`.
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/193
+- PR: pending
+- Follow-up tickets: none
+
+## Notes
+- This restores `repo-health:pilot-step` behavior where strict-clean blocking is governed by the strict gate, not by drift diagnostics capture.

--- a/cli/bb.py
+++ b/cli/bb.py
@@ -336,6 +336,7 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
         "issues_open": [],
         "prs_open": [],
         "latest_pr_checks": None,
+        "warnings": [],
         "errors": [],
     }
 
@@ -372,9 +373,9 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
         cast_errors.append(submodule_err)
 
     if drifts:
-        cast_errors = snapshot["errors"]
-        assert isinstance(cast_errors, list)
-        cast_errors.append(
+        cast_warnings = snapshot["warnings"]
+        assert isinstance(cast_warnings, list)
+        cast_warnings.append(
             "submodule_gitlink_drifts: WARN (submodule commit differs from superproject gitlink)"
         )
 
@@ -514,6 +515,11 @@ def cmd_repo_health(args: argparse.Namespace) -> int:
             assert isinstance(check_lines, list)
             for line in check_lines:
                 lines_out.append(f"  {line}")
+
+        warnings_out = snapshot["warnings"]
+        assert isinstance(warnings_out, list)
+        for warn in warnings_out:
+            lines_out.append(warn)
 
         errors_out = snapshot["errors"]
         assert isinstance(errors_out, list)

--- a/ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh
+++ b/ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh
@@ -53,11 +53,13 @@ try:
         require_clean_worktree=False,
     )
     rc = bb.cmd_repo_health(args)
-    assert rc == 1, rc  # drift warning is emitted as non-zero evidence signal
+    assert rc == 0, rc  # drift warnings should not fail repo-health without strict gate
 
     payload = json.loads(Path("/tmp/repo-health-helper-smoke.json").read_text(encoding="utf-8"))
     drifts = payload.get("submodule_gitlink_drifts", [])
     assert len(drifts) == 1, payload
+    warnings = payload.get("warnings", [])
+    assert any("submodule_gitlink_drifts: WARN" in w for w in warnings), payload
     assert drifts[0]["path"] == "agents/hermes/pm/runtime", payload
     assert drifts[0]["recorded_commit"] == "65a0c089c3e1d10ee6a722bef076ee9a0646ab63", payload
     assert drifts[0]["current_commit"] == "2b1061b012511ad46d7449ab0ac82f4fb595f135", payload
@@ -65,7 +67,7 @@ try:
     # Re-run and capture rendered text path for non-json fields
     args = Namespace(limit=5, json_output=False, out_path="/tmp/repo-health-helper-smoke.txt", require_clean_worktree=False)
     rc = bb.cmd_repo_health(args)
-    assert rc == 1, rc
+    assert rc == 0, rc
 
     txt = Path("/tmp/repo-health-helper-smoke.txt").read_text(encoding="utf-8")
     assert "helper_local_exists:" in txt, txt


### PR DESCRIPTION
## Summary
- classify submodule gitlink drift as `warnings` instead of `errors` in `bb repo-health`
- keep drift diagnostics visible in both JSON and text output
- update deterministic smoke test to enforce non-zero exit is reserved for hard failures
- add BMAD execution artifact for issue #193

## Verification
- `python3 -m py_compile cli/bb.py`
- `bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh`
- `bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh`

Closes #193
