### PR TITLE
feat(bmad): add safe submodule gitlink drift reconcile helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ alongside each service, using publishers generated from the local
 | `mise run bmad:primary-recovery-check -- [--repo <path>]` | read-only divergence diagnostics + helper-availability check for primary checkout recovery |
 | `mise run bmad:align-main-with-backup -- [--repo <path>] [--bundle-dir <path>] [--apply]` | backup-first helper to align diverged local `main` to `origin/main` (read-only by default) |
 | `mise run bmad:recovery-artifact-cleanup -- [--repo <path>] [--bundle-dir <path>] [--keep-branches <n>] [--keep-bundles <n>] [--min-bundle-age-hours <h>] [--apply]` | cleanup helper for post-recovery backup branches + bundle artifacts (dry-run default, optional age gate) |
+| `mise run bmad:reconcile-submodule-drift -- [--repo <path>] [--apply]` | detect/optionally reconcile submodule gitlink drift to superproject recorded commits (read-only default) |
 | `mise run bootstrap`    | `ops/bootstrap/check-platform.sh` — pre-boot validator |
 | `mise run validate:schemas` | Validate the local schema tree (`$id` uniqueness + `$ref` resolution + Draft 2020-12 check) |
 | `mise run smoketest`    | NATS-direct event round-trip                     |
@@ -93,8 +94,9 @@ alongside each service, using publishers generated from the local
 | `mise run smoketest:bmad-primary-recovery-check` | local validation for read-only primary checkout recovery diagnostics contract |
 | `mise run smoketest:bmad-align-main-with-backup` | local validation for backup-first diverged-main alignment helper contract |
 | `mise run smoketest:bmad-recovery-artifact-cleanup` | local validation for backup-branch + bundle cleanup helper contract |
+| `mise run smoketest:bmad-reconcile-submodule-drift` | local validation for submodule gitlink drift reconcile helper contract |
 | `mise run smoketest:hermes-runtime-hygiene` | local validation for Hermes runtime ignore contract (runtime state ignored, skeleton trackable) |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/repo-health-helper-availability/gh-readonly-status/preflight-strict-clean/reconcile-main-divergence/primary-recovery-check/align-main-with-backup/recovery-artifact-cleanup/hermes-runtime-hygiene, fail-fast) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/repo-health-helper-availability/gh-readonly-status/preflight-strict-clean/reconcile-main-divergence/primary-recovery-check/align-main-with-backup/recovery-artifact-cleanup/reconcile-submodule-drift/hermes-runtime-hygiene, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline
@@ -122,6 +124,7 @@ alongside each service, using publishers generated from the local
 - If helper files are missing locally while `main` is diverged, run `mise run bmad:primary-recovery-check` then follow `ops/bmad/primary-checkout-recovery.md` before any destructive sync action.
 - For backup-first canonical alignment, use `mise run bmad:align-main-with-backup -- --repo <path>` (read-only) then rerun with `--apply` only after review.
 - After successful alignment verification window, run `mise run bmad:recovery-artifact-cleanup -- --repo <path>` (dry-run) before any cleanup apply; use `--min-bundle-age-hours` to protect fresh bundles.
+- For persistent submodule gitlink drift (e.g., Hermes PM runtime), run `mise run bmad:reconcile-submodule-drift -- --repo <path>` for diagnostics first, then rerun with `--apply` only when the helper reports no non-drift worktree edits.
 - `bmad:pr-merge-safe` now attempts safe post-merge reconciliation by default; use `--no-reconcile-main` only when you explicitly need to defer reconciliation.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.

--- a/_bmad_output/issue-195-execution.md
+++ b/_bmad_output/issue-195-execution.md
@@ -1,0 +1,31 @@
+# Issue 195 — execution closeout
+
+## Ticket
+- Issue: #195
+- Title: BMAD: add safe reconcile path for Hermes PM submodule gitlink drift
+- Owner: hermes
+
+## Scope completed
+- Added `ops/bmad/reconcile_submodule_gitlink_drift.py` (read-only by default, optional `--apply`) to detect and reconcile submodule gitlink drift back to superproject-recorded commits.
+- Added mise task `bmad:reconcile-submodule-drift`.
+- Added smoketest `ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh` and wired task `smoketest:bmad-reconcile-submodule-drift`.
+- Extended `smoketest:ops` chain to include new drift-reconcile smoketest.
+- Updated `AGENTS.md` task and BMAD guidance references for the new helper workflow.
+
+## Out of scope
+- Automatic invocation of reconcile helper from pilot-step.
+
+## Verification evidence
+- `python3 -m py_compile cli/bb.py ops/bmad/reconcile_submodule_gitlink_drift.py` → success.
+- `bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh` → `PASS`.
+- `bash ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh` → `PASS`.
+- `bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh` → `PASS`.
+- `python3 ops/bmad/reconcile_submodule_gitlink_drift.py --repo /home/delorenj/code/33GOD/bloodbank` → reports current runtime drift with clean diagnostics.
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/195
+- PR: pending
+- Follow-up tickets: none
+
+## Notes
+- Helper apply mode requires `main` branch and refuses when non-drift paths are dirty.

--- a/mise.toml
+++ b/mise.toml
@@ -120,6 +120,10 @@ run = "python3 ops/bmad/align_main_with_backup.py"
 description = "Cleanup helper for backup branches + recovery bundles with optional bundle-age gate (dry-run default)"
 run = "python3 ops/bmad/recovery_artifact_cleanup.py"
 
+[tasks."bmad:reconcile-submodule-drift"]
+description = "Detect/optionally reconcile submodule gitlink drift to superproject recorded commits"
+run = "python3 ops/bmad/reconcile_submodule_gitlink_drift.py"
+
 [tasks."validate:schemas"]
 description = "Validate the local schema tree ($id uniqueness + $ref resolution + Draft 2020-12 check)"
 run = "bash scripts/validate_schemas.sh"
@@ -232,13 +236,17 @@ run = "bash ops/smoketest/smoketest-bmad-align-main-with-backup.sh"
 description = "Local smoke test for backup-branch and bundle cleanup helper"
 run = "bash ops/smoketest/smoketest-bmad-recovery-artifact-cleanup.sh"
 
+[tasks."smoketest:bmad-reconcile-submodule-drift"]
+description = "Local smoke test for submodule gitlink drift reconcile helper"
+run = "bash ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh"
+
 [tasks."smoketest:hermes-runtime-hygiene"]
 description = "Local smoke test for Hermes runtime ignore/track contract"
 run = "bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-repo-health-helper-availability && mise run smoketest:bmad-repo-health-idle-gate && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:bmad-align-main-with-backup && mise run smoketest:bmad-recovery-artifact-cleanup && mise run smoketest:hermes-runtime-hygiene"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-repo-health-helper-availability && mise run smoketest:bmad-repo-health-idle-gate && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:bmad-align-main-with-backup && mise run smoketest:bmad-recovery-artifact-cleanup && mise run smoketest:bmad-reconcile-submodule-drift && mise run smoketest:hermes-runtime-hygiene"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/bmad/reconcile_submodule_gitlink_drift.py
+++ b/ops/bmad/reconcile_submodule_gitlink_drift.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Detect and optionally reconcile submodule gitlink drift.
+
+Default mode is read-only. Use --apply to check out each drifted submodule to the
+commit recorded by the superproject gitlink.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def _run(repo: Path, *cmd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(repo), text=True, capture_output=True, check=False)
+
+
+def _branch(repo: Path) -> str:
+    cp = _run(repo, "git", "rev-parse", "--abbrev-ref", "HEAD")
+    return cp.stdout.strip() if cp.returncode == 0 else ""
+
+
+def _collect_drifts(repo: Path) -> tuple[list[dict[str, str]], list[str]]:
+    errors: list[str] = []
+    cp = _run(repo, "git", "submodule", "status", "--recursive")
+    if cp.returncode != 0:
+        return [], [cp.stderr.strip() or "git submodule status failed"]
+
+    drifts: list[dict[str, str]] = []
+    for raw in cp.stdout.splitlines():
+        line = raw.rstrip()
+        if not line:
+            continue
+        marker = line[0]
+        if marker != "+":
+            continue
+
+        payload = line[1:].strip().split()
+        if len(payload) < 2:
+            continue
+
+        current_commit = payload[0]
+        path = payload[1]
+        detail = " ".join(payload[2:]).strip()
+
+        recorded_commit = ""
+        tree = _run(repo, "git", "ls-tree", "HEAD", path)
+        if tree.returncode == 0 and tree.stdout.strip():
+            parts = tree.stdout.split()
+            if len(parts) >= 3:
+                recorded_commit = parts[2]
+
+        if not recorded_commit:
+            errors.append(f"missing recorded gitlink commit for submodule path: {path}")
+
+        drifts.append(
+            {
+                "path": path,
+                "recorded_commit": recorded_commit,
+                "current_commit": current_commit,
+                "detail": detail,
+            }
+        )
+
+    return drifts, errors
+
+
+def _status_lines(repo: Path) -> list[str]:
+    cp = _run(repo, "git", "status", "--short")
+    if cp.returncode != 0 or not cp.stdout.strip():
+        return []
+    return [line.rstrip() for line in cp.stdout.splitlines() if line.strip()]
+
+
+def evaluate(repo: Path) -> dict[str, object]:
+    drifts, drift_errors = _collect_drifts(repo)
+
+    payload: dict[str, object] = {
+        "ok": len(drift_errors) == 0,
+        "repo": str(repo),
+        "branch": _branch(repo),
+        "drift_count": len(drifts),
+        "drifts": drifts,
+        "recommended_action": (
+            "none"
+            if len(drifts) == 0
+            else "python3 ops/bmad/reconcile_submodule_gitlink_drift.py --repo <repo> --apply"
+        ),
+        "applied": False,
+        "errors": drift_errors,
+    }
+    return payload
+
+
+def _safe_to_apply(repo: Path, drift_paths: set[str]) -> tuple[bool, str]:
+    if _branch(repo) != "main":
+        return False, "apply requires current branch = main"
+
+    lines = _status_lines(repo)
+    disallowed: list[str] = []
+    for line in lines:
+        # status format: XY<space>path
+        if len(line) < 4:
+            continue
+        path = line[3:]
+        if path not in drift_paths:
+            disallowed.append(line)
+
+    if disallowed:
+        return False, f"apply requires clean worktree except listed drift paths; found: {disallowed}"
+
+    return True, "ok"
+
+
+def apply_if_safe(repo: Path, payload: dict[str, object]) -> tuple[bool, str]:
+    drifts = payload.get("drifts")
+    assert isinstance(drifts, list)
+
+    drift_paths = {str(d.get("path", "")) for d in drifts if str(d.get("path", ""))}
+    ok, msg = _safe_to_apply(repo, drift_paths)
+    if not ok:
+        return False, msg
+
+    for drift in drifts:
+        path = str(drift.get("path", ""))
+        recorded = str(drift.get("recorded_commit", ""))
+        if not path or not recorded:
+            return False, f"invalid drift entry: {drift}"
+
+        cp = _run(repo, "git", "-C", path, "checkout", "--detach", recorded)
+        if cp.returncode != 0:
+            return False, cp.stderr.strip() or f"failed to set {path} to {recorded}"
+
+    return True, "applied"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect/reconcile submodule gitlink drift")
+    parser.add_argument("--repo", default=".", help="Repo root (default: .)")
+    parser.add_argument("--apply", action="store_true", help="Apply safe reconciliation when eligible")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    payload = evaluate(repo)
+
+    if args.apply:
+        ok, msg = apply_if_safe(repo, payload)
+        payload["applied"] = ok
+        if not ok:
+            errs = payload.get("errors")
+            if isinstance(errs, list):
+                errs.append(msg)
+            else:
+                payload["errors"] = [msg]
+            print(json.dumps(payload, indent=2))
+            return 1
+
+        payload = evaluate(repo)
+        payload["applied"] = True
+
+    print(json.dumps(payload, indent=2))
+    return 0 if payload.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh
+++ b/ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Local smoke test for submodule drift reconcile helper.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+from pathlib import Path
+
+import ops.bmad.reconcile_submodule_gitlink_drift as m
+
+repo = Path('.').resolve()
+orig_run = m._run
+orig_branch = m._branch
+orig_status_lines = m._status_lines
+
+class CP:
+    def __init__(self, returncode=0, stdout='', stderr=''):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+try:
+    # evaluate(): detects one drift and records commits.
+    def fake_run_eval(_repo, *cmd):
+        if cmd[:4] == ('git', 'submodule', 'status', '--recursive'):
+            return CP(0, '+2b1061b012511ad46d7449ab0ac82f4fb595f135 agents/hermes/pm/runtime (heads/main)\n')
+        if cmd[:3] == ('git', 'ls-tree', 'HEAD'):
+            return CP(0, '160000 commit 65a0c089c3e1d10ee6a722bef076ee9a0646ab63\tagents/hermes/pm/runtime\n')
+        if cmd[:3] == ('git', 'rev-parse', '--abbrev-ref'):
+            return CP(0, 'main\n')
+        return CP(0, '')
+
+    m._run = fake_run_eval
+    payload = m.evaluate(repo)
+    assert payload['ok'] is True, payload
+    assert payload['drift_count'] == 1, payload
+    drifts = payload['drifts']
+    assert isinstance(drifts, list) and drifts[0]['path'] == 'agents/hermes/pm/runtime', payload
+
+    # apply_if_safe(): blocks off-main.
+    m._branch = lambda _repo: 'feature/test'
+    ok, msg = m.apply_if_safe(repo, payload)
+    assert ok is False and 'current branch = main' in msg, (ok, msg)
+
+    # apply_if_safe(): blocks extra dirty paths.
+    m._branch = lambda _repo: 'main'
+    m._status_lines = lambda _repo: [' M agents/hermes/pm/runtime', ' M cli/bb.py']
+    ok, msg = m.apply_if_safe(repo, payload)
+    assert ok is False and 'clean worktree except listed drift paths' in msg, (ok, msg)
+
+    # apply_if_safe(): success path executes checkout.
+    calls = []
+
+    def fake_run_apply(_repo, *cmd):
+        calls.append(cmd)
+        if cmd[:3] == ('git', 'submodule', 'status'):
+            return CP(0, '+2b1061b012511ad46d7449ab0ac82f4fb595f135 agents/hermes/pm/runtime (heads/main)\n')
+        if cmd[:3] == ('git', 'ls-tree', 'HEAD'):
+            return CP(0, '160000 commit 65a0c089c3e1d10ee6a722bef076ee9a0646ab63\tagents/hermes/pm/runtime\n')
+        if cmd[:3] == ('git', 'rev-parse', '--abbrev-ref'):
+            return CP(0, 'main\n')
+        if cmd[:3] == ('git', '-C', 'agents/hermes/pm/runtime'):
+            return CP(0, '')
+        return CP(0, '')
+
+    m._run = fake_run_apply
+    m._status_lines = lambda _repo: [' M agents/hermes/pm/runtime']
+    ok, msg = m.apply_if_safe(repo, payload)
+    assert ok is True and msg == 'applied', (ok, msg)
+    assert any(cmd[:3] == ('git', '-C', 'agents/hermes/pm/runtime') for cmd in calls), calls
+
+finally:
+    m._run = orig_run
+    m._branch = orig_branch
+    m._status_lines = orig_status_lines
+PY
+
+echo "smoketest-bmad-reconcile-submodule-drift: PASS"


### PR DESCRIPTION
## Summary
- add `ops/bmad/reconcile_submodule_gitlink_drift.py` helper (read-only by default, optional `--apply`)
- add `bmad:reconcile-submodule-drift` task and `smoketest:bmad-reconcile-submodule-drift`
- extend `smoketest:ops` chain to include drift reconcile coverage
- add/update BMAD docs references in `AGENTS.md`
- add issue execution artifact for #195

## Verification
- `python3 -m py_compile cli/bb.py ops/bmad/reconcile_submodule_gitlink_drift.py`
- `bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh`
- `bash ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh`
- `bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh`
- `python3 ops/bmad/reconcile_submodule_gitlink_drift.py --repo /home/delorenj/code/33GOD/bloodbank`

Closes #195
