### PR TITLE
fix(repo-health): auto-heal pilot strict gate on submodule drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ alongside each service, using publishers generated from the local
 | `mise run smoketest:bmad-recovery-artifact-cleanup` | local validation for backup-branch + bundle cleanup helper contract |
 | `mise run smoketest:bmad-reconcile-submodule-drift` | local validation for submodule gitlink drift reconcile helper contract |
 | `mise run smoketest:hermes-runtime-hygiene` | local validation for Hermes runtime ignore contract (runtime state ignored, skeleton trackable) |
-| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/repo-health-helper-availability/gh-readonly-status/preflight-strict-clean/reconcile-main-divergence/primary-recovery-check/align-main-with-backup/recovery-artifact-cleanup/reconcile-submodule-drift/hermes-runtime-hygiene, fail-fast) |
+| `mise run smoketest:ops` | consolidated local operator reliability smoke checks (cleanup/scaffold/closeout-loop/merge-safe/merge-preflight-guard/retrigger-checks/github-body-safety/cleanup-summary/artifact-summary/repo-health-retry/repo-health-helper-availability/repo-health-idle-gate/repo-health-pilot-step-autoheal/gh-readonly-status/preflight-strict-clean/reconcile-main-divergence/primary-recovery-check/align-main-with-backup/recovery-artifact-cleanup/reconcile-submodule-drift/hermes-runtime-hygiene, fail-fast) |
 | `mise run logs`         | Tail every Bloodbank container                   |
 
 ## BMAD baseline
@@ -125,6 +125,7 @@ alongside each service, using publishers generated from the local
 - For backup-first canonical alignment, use `mise run bmad:align-main-with-backup -- --repo <path>` (read-only) then rerun with `--apply` only after review.
 - After successful alignment verification window, run `mise run bmad:recovery-artifact-cleanup -- --repo <path>` (dry-run) before any cleanup apply; use `--min-bundle-age-hours` to protect fresh bundles.
 - For persistent submodule gitlink drift (e.g., Hermes PM runtime), run `mise run bmad:reconcile-submodule-drift -- --repo <path>` for diagnostics first, then rerun with `--apply` only when the helper reports no non-drift worktree edits.
+- `repo-health:pilot-step` may auto-heal strict-gate failures by applying the submodule drift helper once (`DRIFT_AUTOHEAL_ON_STRICT_FAIL=1` default); disable with `DRIFT_AUTOHEAL_ON_STRICT_FAIL=0` when manual intervention is desired.
 - `bmad:pr-merge-safe` now attempts safe post-merge reconciliation by default; use `--no-reconcile-main` only when you explicitly need to defer reconciliation.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.

--- a/_bmad_output/issue-197-execution.md
+++ b/_bmad_output/issue-197-execution.md
@@ -1,0 +1,32 @@
+# Issue 197 — execution closeout
+
+## Ticket
+- Issue: #197
+- Title: BMAD: add pilot-step drift auto-heal for Hermes PM submodule checkpoint churn
+- Owner: hermes
+
+## Scope completed
+- Updated `ops/repo-health/pilot_step.sh` with one-shot strict-fail auto-heal flow:
+  - run strict gate
+  - on strict failure, run `ops/bmad/reconcile_submodule_gitlink_drift.py --apply`
+  - retry strict gate once
+- Added `DRIFT_AUTOHEAL_ON_STRICT_FAIL` env toggle (default `1`; set `0` to disable).
+- Added deterministic smoke coverage `ops/smoketest/smoketest-bmad-repo-health-pilot-step-autoheal.sh`.
+- Wired new smoketest into `mise.toml` (`smoketest:bmad-repo-health-pilot-step-autoheal`) and `smoketest:ops` chain.
+- Updated `AGENTS.md` task table + guidance for pilot-step auto-heal behavior.
+
+## Out of scope
+- Automatic ticket creation/escalation for repeated drift events.
+
+## Verification evidence
+- `bash ops/smoketest/smoketest-bmad-repo-health-idle-gate.sh` → PASS.
+- `bash ops/smoketest/smoketest-bmad-repo-health-pilot-step-autoheal.sh` → PASS.
+- `bash ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh` → PASS.
+
+## Links
+- Issue: https://github.com/delorenj/bloodbank/issues/197
+- PR: pending
+- Follow-up tickets: none
+
+## Notes
+- Auto-heal remains guardrailed by reconcile helper safety checks (main branch + no non-drift dirty paths).

--- a/mise.toml
+++ b/mise.toml
@@ -212,6 +212,10 @@ run = "bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh"
 description = "Local smoke test for idle-state repo-health throttle decision helper"
 run = "bash ops/smoketest/smoketest-bmad-repo-health-idle-gate.sh"
 
+[tasks."smoketest:bmad-repo-health-pilot-step-autoheal"]
+description = "Local smoke test for pilot-step strict-fail submodule drift auto-heal path"
+run = "bash ops/smoketest/smoketest-bmad-repo-health-pilot-step-autoheal.sh"
+
 [tasks."smoketest:bmad-gh-readonly-status"]
 description = "Local smoke test for read-only gh status helper retry behavior"
 run = "bash ops/smoketest/smoketest-bmad-gh-readonly-status.sh"
@@ -246,7 +250,7 @@ run = "bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh"
 
 [tasks."smoketest:ops"]
 description = "Run consolidated local operator reliability smoke checks (fail-fast)"
-run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-repo-health-helper-availability && mise run smoketest:bmad-repo-health-idle-gate && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:bmad-align-main-with-backup && mise run smoketest:bmad-recovery-artifact-cleanup && mise run smoketest:bmad-reconcile-submodule-drift && mise run smoketest:hermes-runtime-hygiene"
+run = "mise run smoketest:repo-health-cleanup && mise run smoketest:bmad-closeout-scaffold && mise run smoketest:bmad-closeout-loop && mise run smoketest:bmad-merge-pr-safe && mise run smoketest:bmad-merge-pr-preflight-guard && mise run smoketest:bmad-retrigger-pr-checks && mise run smoketest:bmad-github-body-safety && mise run smoketest:bmad-closeout-cleanup-summary && mise run smoketest:bmad-closeout-artifact-summary && mise run smoketest:bmad-repo-health-retry && mise run smoketest:bmad-repo-health-helper-availability && mise run smoketest:bmad-repo-health-idle-gate && mise run smoketest:bmad-repo-health-pilot-step-autoheal && mise run smoketest:bmad-gh-readonly-status && mise run smoketest:bmad-preflight-strict-clean && mise run smoketest:bmad-reconcile-main-divergence && mise run smoketest:bmad-primary-recovery-check && mise run smoketest:bmad-align-main-with-backup && mise run smoketest:bmad-recovery-artifact-cleanup && mise run smoketest:bmad-reconcile-submodule-drift && mise run smoketest:hermes-runtime-hygiene"
 
 [tasks.logs]
 description = "Tail every Bloodbank container"

--- a/ops/repo-health/pilot_step.sh
+++ b/ops/repo-health/pilot_step.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 # Hermes pilot loop helper:
 # - evaluate idle gate from repo-health snapshot
 # - always run strict cleanliness gate
+# - on strict failure, optionally attempt submodule-drift auto-heal once
 # - run full artifact+cleanup only when gate requires it
 
 INTERVAL_MINUTES="${INTERVAL_MINUTES:-60}"
 KEEP="${KEEP:-8}"
 REPORT="${REPORT:-1}"
+DRIFT_AUTOHEAL_ON_STRICT_FAIL="${DRIFT_AUTOHEAL_ON_STRICT_FAIL:-1}"
 
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 DECISION_OUT="_bmad_output/evidence/repo-health-idle-decision-${TS}.json"
@@ -61,8 +63,28 @@ print('1' if d.get('should_capture_full') else '0')
 PY
 } )"
 
+run_strict_with_autoheal() {
+  if mise run repo-health:strict; then
+    return 0
+  fi
+
+  if [[ "$DRIFT_AUTOHEAL_ON_STRICT_FAIL" != "1" ]]; then
+    echo "repo-health:strict failed (auto-heal disabled)"
+    return 1
+  fi
+
+  echo "repo-health:strict failed; attempting submodule drift auto-heal"
+  if ! python3 ops/bmad/reconcile_submodule_gitlink_drift.py --repo . --apply; then
+    echo "repo-health:strict auto-heal attempt failed"
+    return 1
+  fi
+
+  echo "repo-health:strict drift auto-heal applied; retrying strict gate"
+  mise run repo-health:strict
+}
+
 # Always run strict gate for repo safety and liveness evidence in logs.
-mise run repo-health:strict
+run_strict_with_autoheal
 
 if [[ "$SHOULD_CAPTURE_FULL" == "1" ]]; then
   mise run repo-health:artifact

--- a/ops/smoketest/smoketest-bmad-repo-health-pilot-step-autoheal.sh
+++ b/ops/smoketest/smoketest-bmad-repo-health-pilot-step-autoheal.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Deterministic smoke test for pilot-step strict-fail submodule-drift auto-heal path.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/ops/repo-health" "$TMPDIR/ops/bmad" "$TMPDIR/_bmad_output/evidence" "$TMPDIR/fakebin"
+cp ops/repo-health/pilot_step.sh "$TMPDIR/ops/repo-health/pilot_step.sh"
+cp ops/repo-health/idle_gate.py "$TMPDIR/ops/repo-health/idle_gate.py"
+chmod +x "$TMPDIR/ops/repo-health/pilot_step.sh"
+
+cat > "$TMPDIR/ops/bmad/reconcile_submodule_gitlink_drift.py" <<'PY'
+#!/usr/bin/env python3
+from pathlib import Path
+Path('.autoheal-marker').write_text('applied\n', encoding='utf-8')
+print('{"ok": true, "applied": true}')
+PY
+chmod +x "$TMPDIR/ops/bmad/reconcile_submodule_gitlink_drift.py"
+
+cat > "$TMPDIR/snapshot.json" <<'JSON'
+{
+  "git_status": "## main...origin/main",
+  "worktree_dirty": false,
+  "issues_open": [],
+  "prs_open": []
+}
+JSON
+
+cat > "$TMPDIR/fakebin/mise" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+state_file=".strict-call-count"
+count=0
+if [[ -f "$state_file" ]]; then
+  count="$(cat "$state_file")"
+fi
+
+if [[ "$1" != "run" ]]; then
+  echo "unexpected mise invocation: $*" >&2
+  exit 2
+fi
+
+case "$2" in
+  repo-health:strict)
+    count=$((count + 1))
+    echo "$count" > "$state_file"
+    if [[ "$count" -eq 1 ]]; then
+      echo "simulated strict fail" >&2
+      exit 1
+    fi
+    echo "simulated strict pass"
+    exit 0
+    ;;
+  repo-health:artifact)
+    : > .artifact-ran
+    exit 0
+    ;;
+  repo-health:cleanup)
+    : > .cleanup-ran
+    exit 0
+    ;;
+  *)
+    echo "unexpected task: $2" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$TMPDIR/fakebin/mise"
+
+(
+  cd "$TMPDIR"
+  PATH="$TMPDIR/fakebin:$PATH" \
+  SNAPSHOT_PATH="$TMPDIR/snapshot.json" \
+  INTERVAL_MINUTES=60 \
+  KEEP=2 \
+  REPORT=1 \
+  DRIFT_AUTOHEAL_ON_STRICT_FAIL=1 \
+  bash ops/repo-health/pilot_step.sh > "$TMPDIR/out.log" 2>&1
+)
+
+grep -q "repo-health:strict failed; attempting submodule drift auto-heal" "$TMPDIR/out.log"
+grep -q "repo-health:strict drift auto-heal applied; retrying strict gate" "$TMPDIR/out.log"
+test -f "$TMPDIR/.autoheal-marker"
+
+test "$(cat "$TMPDIR/.strict-call-count")" = "2"
+
+echo "smoketest-bmad-repo-health-pilot-step-autoheal: PASS"


### PR DESCRIPTION
## Summary
- add strict-fail auto-heal path in `ops/repo-health/pilot_step.sh` for drift-only submodule strict gate failures
- introduce `DRIFT_AUTOHEAL_ON_STRICT_FAIL` toggle (default enabled)
- add deterministic smoke test `smoketest-bmad-repo-health-pilot-step-autoheal.sh`
- wire new smoketest into `mise.toml` (`smoketest:bmad-repo-health-pilot-step-autoheal`, `smoketest:ops`)
- document behavior in `AGENTS.md`
- include issue #197 execution artifact

## Verification
- `bash ops/smoketest/smoketest-bmad-repo-health-idle-gate.sh`
- `bash ops/smoketest/smoketest-bmad-repo-health-pilot-step-autoheal.sh`
- `bash ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh`

Closes #197
