### PR TITLE
fix(issue-213): unblock runtime submodule reconcile on state.db drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ alongside each service, using publishers generated from the local
 - If helper files are missing locally while `main` is diverged, run `mise run bmad:primary-recovery-check` then follow `ops/bmad/primary-checkout-recovery.md` before any destructive sync action.
 - For backup-first canonical alignment, use `mise run bmad:align-main-with-backup -- --repo <path>` (read-only) then rerun with `--apply` only after review.
 - After successful alignment verification window, run `mise run bmad:recovery-artifact-cleanup -- --repo <path>` (dry-run) before any cleanup apply; use `--min-bundle-age-hours` to protect fresh bundles.
-- For persistent submodule gitlink drift (e.g., Hermes PM runtime), run `mise run bmad:reconcile-submodule-drift -- --repo <path>` for diagnostics first, then rerun with `--apply` only when the helper reports no non-drift worktree edits.
+- For persistent submodule gitlink drift (e.g., Hermes PM runtime), run `mise run bmad:reconcile-submodule-drift -- --repo <path>` for diagnostics first, then rerun with `--apply` only when the helper reports no non-drift worktree edits. The helper now retries with a forced checkout for the known runtime `state.db` overwrite blocker on `agents/hermes/pm/runtime`.
 - `repo-health:pilot-step` may auto-heal strict-gate failures by applying the submodule drift helper once (`DRIFT_AUTOHEAL_ON_STRICT_FAIL=1` default); disable with `DRIFT_AUTOHEAL_ON_STRICT_FAIL=0` when manual intervention is desired.
 - `bmad:pr-merge-safe` now attempts safe post-merge reconciliation by default; use `--no-reconcile-main` only when you explicitly need to defer reconciliation.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.

--- a/_bmad_output/issue-213-execution.md
+++ b/_bmad_output/issue-213-execution.md
@@ -1,0 +1,23 @@
+# Issue 213 — execution log
+
+## Ticket
+- Issue: #213
+- Title: BMAD: reconcile blocked by tracked runtime state.db drift
+
+## Problem reproduced
+- `bmad:reconcile-submodule-drift --apply` failed when runtime submodule was at drifted commit `2b1061b`.
+- Blocking stderr included: `state.db would be overwritten by checkout`.
+
+## Forward step implemented
+- Hardened `ops/bmad/reconcile_submodule_gitlink_drift.py`:
+  - On known runtime path `agents/hermes/pm/runtime`, if checkout fails with the `state.db` overwrite pattern, retry with `git checkout --detach -f <recorded>`.
+  - Keeps strict behavior for all other paths/errors.
+- Added smoketest coverage in `ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh` for this forced-checkout retry path.
+- Updated AGENTS operator guidance to document the runtime `state.db` fallback behavior.
+
+## Verification
+- `bash ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh` => PASS
+
+## Next
+- Open PR, run checks, merge.
+- Re-run `mise run bmad:reconcile-submodule-drift -- --repo /home/delorenj/code/33GOD/bloodbank --apply` in primary checkout to confirm blocker is cleared.

--- a/ops/bmad/reconcile_submodule_gitlink_drift.py
+++ b/ops/bmad/reconcile_submodule_gitlink_drift.py
@@ -12,6 +12,8 @@ import json
 import subprocess
 from pathlib import Path
 
+RUNTIME_FORCE_CHECKOUT_PATHS = {"agents/hermes/pm/runtime"}
+
 
 def _run(repo: Path, *cmd: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, cwd=str(repo), text=True, capture_output=True, check=False)
@@ -114,6 +116,13 @@ def _safe_to_apply(repo: Path, drift_paths: set[str]) -> tuple[bool, str]:
     return True, "ok"
 
 
+def _runtime_force_checkout_allowed(path: str, stderr: str) -> bool:
+    if path not in RUNTIME_FORCE_CHECKOUT_PATHS:
+        return False
+    lower = (stderr or "").lower()
+    return "would be overwritten by checkout" in lower and "state.db" in lower
+
+
 def apply_if_safe(repo: Path, payload: dict[str, object]) -> tuple[bool, str]:
     drifts = payload.get("drifts")
     assert isinstance(drifts, list)
@@ -130,8 +139,17 @@ def apply_if_safe(repo: Path, payload: dict[str, object]) -> tuple[bool, str]:
             return False, f"invalid drift entry: {drift}"
 
         cp = _run(repo, "git", "-C", path, "checkout", "--detach", recorded)
-        if cp.returncode != 0:
-            return False, cp.stderr.strip() or f"failed to set {path} to {recorded}"
+        if cp.returncode == 0:
+            continue
+
+        stderr = cp.stderr.strip()
+        if _runtime_force_checkout_allowed(path, stderr):
+            retry = _run(repo, "git", "-C", path, "checkout", "--detach", "-f", recorded)
+            if retry.returncode == 0:
+                continue
+            stderr = retry.stderr.strip() or stderr
+
+        return False, stderr or f"failed to set {path} to {recorded}"
 
     return True, "applied"
 

--- a/ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh
+++ b/ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh
@@ -72,6 +72,23 @@ try:
     assert ok is True and msg == 'applied', (ok, msg)
     assert any(cmd[:3] == ('git', '-C', 'agents/hermes/pm/runtime') for cmd in calls), calls
 
+    # apply_if_safe(): runtime state.db overwrite blocker retries with forced checkout.
+    calls_force = []
+
+    def fake_run_force(_repo, *cmd):
+        calls_force.append(cmd)
+        if cmd[:5] == ('git', '-C', 'agents/hermes/pm/runtime', 'checkout', '--detach') and '-f' not in cmd:
+            return CP(1, '', 'error: Your local changes to the following files would be overwritten by checkout:\n\tstate.db\nPlease commit your changes or stash them before you switch branches.\nAborting')
+        if cmd[:6] == ('git', '-C', 'agents/hermes/pm/runtime', 'checkout', '--detach', '-f'):
+            return CP(0, '', '')
+        return CP(0, '', '')
+
+    m._run = fake_run_force
+    m._status_lines = lambda _repo: [' M agents/hermes/pm/runtime']
+    ok, msg = m.apply_if_safe(repo, payload)
+    assert ok is True and msg == 'applied', (ok, msg)
+    assert any(cmd[:6] == ('git', '-C', 'agents/hermes/pm/runtime', 'checkout', '--detach', '-f') for cmd in calls_force), calls_force
+
 finally:
     m._run = orig_run
     m._branch = orig_branch


### PR DESCRIPTION
## Summary
Unblock submodule drift auto-heal when Hermes runtime checkout is on a drifted commit that still tracks `state.db`.

## Changes
- `ops/bmad/reconcile_submodule_gitlink_drift.py`
  - keep strict preflight gate behavior
  - add guarded fallback for runtime path `agents/hermes/pm/runtime`:
    - if checkout fails with `state.db would be overwritten by checkout`, retry with `git checkout --detach -f <recorded>`
  - keep hard-fail semantics for all other paths/errors
- `ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh`
  - add coverage for the state.db overwrite + forced-checkout retry path
- `AGENTS.md`
  - document the runtime state.db fallback behavior
- `_bmad_output/issue-213-execution.md`
  - ticket evidence + verification log

## Verification
- `bash ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh` -> PASS

## Links
- Closes #213
