### PR TITLE
fix(bmad): allow _bmad_output evidence in submodule drift apply gate

### DIFF
--- a/ops/bmad/reconcile_submodule_gitlink_drift.py
+++ b/ops/bmad/reconcile_submodule_gitlink_drift.py
@@ -13,6 +13,7 @@ import subprocess
 from pathlib import Path
 
 RUNTIME_FORCE_CHECKOUT_PATHS = {"agents/hermes/pm/runtime"}
+BMAD_EVIDENCE_PATH_PREFIXES = ("_bmad_output",)
 
 
 def _run(repo: Path, *cmd: str) -> subprocess.CompletedProcess[str]:
@@ -107,6 +108,8 @@ def _safe_to_apply(repo: Path, drift_paths: set[str]) -> tuple[bool, str]:
         if len(line) < 4:
             continue
         path = line[3:]
+        if any(path == prefix or path.startswith(f"{prefix}/") for prefix in BMAD_EVIDENCE_PATH_PREFIXES):
+            continue
         if path not in drift_paths:
             disallowed.append(line)
 

--- a/ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh
+++ b/ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh
@@ -45,6 +45,12 @@ try:
     ok, msg = m.apply_if_safe(repo, payload)
     assert ok is False and 'current branch = main' in msg, (ok, msg)
 
+    # apply_if_safe(): allows BMAD evidence output paths.
+    m._branch = lambda _repo: 'main'
+    m._status_lines = lambda _repo: [' M agents/hermes/pm/runtime', '?? _bmad_output/']
+    ok, msg = m.apply_if_safe(repo, payload)
+    assert ok is True and msg == 'applied', (ok, msg)
+
     # apply_if_safe(): blocks extra dirty paths.
     m._branch = lambda _repo: 'main'
     m._status_lines = lambda _repo: [' M agents/hermes/pm/runtime', ' M cli/bb.py']


### PR DESCRIPTION
## Summary
Fixes a pilot-loop blocker where BMAD evidence logging under `_bmad_output/` prevented `bmad:reconcile-submodule-drift --apply` from running.

## Changes
- `ops/bmad/reconcile_submodule_gitlink_drift.py`
  - allow `_bmad_output` paths in apply preflight cleanliness gate
  - keep strictness for all other non-drift paths
- `ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh`
  - add regression assertion that `?? _bmad_output/` no longer blocks apply

## Why
Issue #215 showed the helper failed with:
`apply requires clean worktree except listed drift paths; found: ['?? _bmad_output/']`

## Verification
- `bash ops/smoketest/smoketest-bmad-reconcile-submodule-drift.sh` ✅

Closes #215
