### PR TITLE
fix(ci): soft-fail Gemini review job on external API/auth errors

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -44,6 +44,7 @@ jobs:
       - name: 'Run Gemini pull request review'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'gemini_pr_review'
+        continue-on-error: true
         env:
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
@@ -277,3 +278,9 @@ jobs:
             ## Final Instructions
 
             Remember, you are running in a virtual machine and no one reviewing your output. Your review must be posted to GitHub using the MCP tools to create a pending review, add comments to the pending review, and submit the pending review.
+
+      - name: 'Report Gemini review soft-failure'
+        if: |-
+          ${{ steps.gemini_pr_review.outcome == 'failure' }}
+        run: |-
+          echo 'Gemini review step failed (likely external API/auth configuration). Soft-fail is enabled to avoid blocking unrelated PRs.'


### PR DESCRIPTION
## Summary
Mitigates blocker #224 by making the Gemini review step soft-fail instead of hard-fail when external Gemini API/auth is broken.

## Changes
- `.github/workflows/gemini-review.yml`
  - added `continue-on-error: true` to `Run Gemini pull request review` step
  - added a follow-up reporting step when the Gemini review outcome is failure

## Why
Current PRs are blocked by external credential failures (`API_KEY_INVALID`) unrelated to code correctness. This keeps CI moving while key rotation/repair is handled.

## Validation
```bash
mise x actionlint@1.7.7 shellcheck@0.10.0 -- actionlint .github/workflows/gemini-review.yml
```
Passed.

Refs #224
