### PR TITLE
feat(audio): add audio domain event contracts

### DIFF
--- a/docs/event-naming.md
+++ b/docs/event-naming.md
@@ -173,6 +173,7 @@ Segment 3 of `type` MUST be one of:
 | `cli`          | Terminal/process-backed agent runtimes (stdin/stdout/stderr/exit). | active   |
 | `tool`         | Tool-call lifecycle (request, invoke, complete) regardless of CLI. | active   |
 | `system`       | Bloodbank platform health (heartbeats, dapr, nats, replay).        | active   |
+| `audio`        | Audio capture lifecycle — inbox ingestion, transcription jobs.     | active   |
 | `approval`     | Human-in-the-loop approval grants/denies.                          | reserved |
 | `workspace`    | Working directory / git state mutations.                           | reserved |
 | `workflow`     | Multi-step workflow orchestration.                                 | reserved |
@@ -201,6 +202,8 @@ Segment 4 of `type` MUST be one of:
 | `response`         | `llm`                    | A response received from an LLM provider.                   |
 | `tool_call`        | `tool`                   | An agent's intent to call a tool. Underscore form.          |
 | `heartbeat`        | `system`                 | Liveness/health beat.                                       |
+| `file`             | `audio`                  | An on-disk audio artifact observed by an inbox watcher.     |
+| `transcription`    | `audio`                  | A speech-to-text job over a single audio file.              |
 | `approval_request` | `approval` (reserved)    | Human approval prompt issued.                               |
 | `worktree`         | `workspace` (reserved)   | Git worktree lifecycle.                                     |
 | `branch`           | `workspace` (reserved)   | Git branch state changes.                                   |
@@ -323,11 +326,16 @@ turn:<turn_id>
 invocation:<invocation_id>
 cli_session:<session_id>
 process:<process_id>
+transcription:<transcription_id>
+file:<sha256(file_path)|file_id>
 ```
 
 Pick the narrowest bucket that captures the event's natural ordering.
 A `conversation.message.appended` uses `turn:<turn_id>`. A
-`cli.stdout.appended` uses `process:<process_id>`.
+`cli.stdout.appended` uses `process:<process_id>`. An
+`audio.transcription.completed` uses `transcription:<transcription_id>`;
+an `audio.file.received` uses `file:<sha256(file_path)>` so re-detections
+of the same artifact form a stable bucket.
 
 ### 11.2 `idempotency_key` rules
 

--- a/schemas/bloodbank/v1/audio/file.received.v1.json
+++ b/schemas/bloodbank/v1/audio/file.received.v1.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://33god.dev/schemas/bloodbank/v1/audio/file.received.v1.json",
+  "title": "Audio File Received Event",
+  "description": "An audio file was observed appearing in a watched inbox directory (e.g. ~/audio/inbox). Producer is the inbox watcher. The same file_path may legitimately re-fire on re-detect/rescan; use ordering_key bucket 'file:<sha256(file_path)>' so dedup downstream is stable. See bloodbank/docs/event-naming.md.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../../../_common/cloudevent_base.v1.json"
+    }
+  ],
+  "properties": {
+    "type": {
+      "const": "bloodbank.v1.audio.file.received"
+    },
+    "kind": {
+      "const": "event"
+    },
+    "domain": {
+      "const": "audio"
+    },
+    "data": {
+      "type": "object",
+      "description": "Payload for bloodbank.v1.audio.file.received.",
+      "properties": {
+        "file_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path to the detected audio file on disk."
+        },
+        "file_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Basename of the file, for convenience and display."
+        },
+        "inbox_dir": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Absolute path of the inbox directory the watcher is observing."
+        },
+        "file_size_bytes": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Size of the file on disk in bytes at the time of detection."
+        },
+        "mime_type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Detected MIME type (e.g. 'audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/x-m4a')."
+        },
+        "file_hash_sha256": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[a-f0-9]{64}$",
+          "description": "SHA-256 hex digest of the file contents for dedup across re-detections."
+        },
+        "duration_seconds": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Duration of the audio in seconds, if probeable at detect time."
+        },
+        "detected_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time",
+          "description": "RFC3339 timestamp when the watcher first observed the file. May differ from envelope.time if detection was queued."
+        }
+      },
+      "required": [
+        "file_path"
+      ],
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "type",
+    "kind",
+    "domain",
+    "data"
+  ]
+}

--- a/schemas/bloodbank/v1/audio/transcription.completed.v1.json
+++ b/schemas/bloodbank/v1/audio/transcription.completed.v1.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://33god.dev/schemas/bloodbank/v1/audio/transcription.completed.v1.json",
+  "title": "Audio Transcription Completed Event",
+  "description": "A transcription job finished successfully and the transcript is available. For long transcripts the full text MAY be stored externally and referenced via transcript_uri instead of being inlined in transcript_text. Use ordering_key 'transcription:<transcription_id>'. See bloodbank/docs/event-naming.md.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../../../_common/cloudevent_base.v1.json"
+    }
+  ],
+  "properties": {
+    "type": {
+      "const": "bloodbank.v1.audio.transcription.completed"
+    },
+    "kind": {
+      "const": "event"
+    },
+    "domain": {
+      "const": "audio"
+    },
+    "data": {
+      "type": "object",
+      "description": "Payload for bloodbank.v1.audio.transcription.completed.",
+      "properties": {
+        "transcription_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Same transcription_id as the originating started event."
+        },
+        "file_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path of the audio file that was transcribed."
+        },
+        "transcript_text": {
+          "type": "string",
+          "description": "Final transcript text. May be empty for silent or non-speech audio. Producers MAY truncate very long transcripts and rely on transcript_uri for the canonical full text."
+        },
+        "transcript_uri": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri-reference",
+          "description": "Optional URI to the canonical full transcript (e.g. file://, s3://, https://). Use when transcript_text is too large to inline or has been truncated."
+        },
+        "language_detected": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Engine-detected language as BCP-47 (e.g. 'en'). Null if not provided by the engine."
+        },
+        "duration_seconds": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Duration of the audio in seconds."
+        },
+        "processing_seconds": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Wall-clock time the engine spent transcribing in seconds."
+        },
+        "word_count": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Word count of transcript_text (or the canonical transcript when transcript_uri is set)."
+        },
+        "confidence": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Aggregate engine confidence in [0,1]. Null if the engine does not report confidence."
+        },
+        "engine": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Transcription engine that produced this result."
+        },
+        "engine_model": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Specific model variant under the engine."
+        },
+        "segments": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Optional time-aligned segments. Each item is {start_seconds, end_seconds, text, confidence?}. Producers MAY omit for cost; consumers MUST tolerate either shape.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "start_seconds": {
+                "type": "number",
+                "minimum": 0
+              },
+              "end_seconds": {
+                "type": "number",
+                "minimum": 0
+              },
+              "text": {
+                "type": "string"
+              },
+              "confidence": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "required": [
+              "start_seconds",
+              "end_seconds",
+              "text"
+            ],
+            "additionalProperties": true
+          }
+        }
+      },
+      "required": [
+        "transcription_id",
+        "file_path",
+        "transcript_text"
+      ],
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "type",
+    "kind",
+    "domain",
+    "data"
+  ]
+}

--- a/schemas/bloodbank/v1/audio/transcription.failed.v1.json
+++ b/schemas/bloodbank/v1/audio/transcription.failed.v1.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://33god.dev/schemas/bloodbank/v1/audio/transcription.failed.v1.json",
+  "title": "Audio Transcription Failed Event",
+  "description": "A transcription job terminated with an error. Use this for any non-recoverable failure during the transcription pipeline (file unreadable, engine error, timeout, OOM, etc.). The 'retryable' flag tells downstream orchestrators whether re-issuing the start command is safe. Use ordering_key 'transcription:<transcription_id>'. See bloodbank/docs/event-naming.md.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../../../_common/cloudevent_base.v1.json"
+    }
+  ],
+  "properties": {
+    "type": {
+      "const": "bloodbank.v1.audio.transcription.failed"
+    },
+    "kind": {
+      "const": "event"
+    },
+    "domain": {
+      "const": "audio"
+    },
+    "data": {
+      "type": "object",
+      "description": "Payload for bloodbank.v1.audio.transcription.failed.",
+      "properties": {
+        "transcription_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Same transcription_id as the originating started event (if one was emitted)."
+        },
+        "file_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path of the audio file the failed job was operating on."
+        },
+        "error_code": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Producer-defined short code (e.g. 'engine.timeout', 'file.unreadable', 'audio.unsupported_codec', 'engine.oom')."
+        },
+        "error_message": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Human-readable error description."
+        },
+        "retryable": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "True when the orchestrator MAY safely re-issue the same audio.transcription.start command. False for permanent failures (e.g. corrupted file). Null when the producer cannot determine."
+        },
+        "engine": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Transcription engine that failed."
+        },
+        "engine_model": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Specific model variant under the engine."
+        }
+      },
+      "required": [
+        "transcription_id",
+        "file_path"
+      ],
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "type",
+    "kind",
+    "domain",
+    "data"
+  ]
+}

--- a/schemas/bloodbank/v1/audio/transcription.start.v1.json
+++ b/schemas/bloodbank/v1/audio/transcription.start.v1.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://33god.dev/schemas/bloodbank/v1/audio/transcription.start.v1.json",
+  "title": "Audio Transcription Start Command",
+  "description": "Imperative request to transcribe a single audio file. Consumed by the transcription service. The service answers with audio.transcription.started (acceptance) and eventually audio.transcription.completed or audio.transcription.failed. Per docs/event-naming.md §11.2 the recommended idempotency_key shape is 'audio.transcription.start:file:<sha256(file_path)>' so re-issuing the same logical request collapses.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../../../_common/cloudevent_base.v1.json"
+    }
+  ],
+  "properties": {
+    "type": {
+      "const": "bloodbank.v1.audio.transcription.start"
+    },
+    "kind": {
+      "const": "command"
+    },
+    "domain": {
+      "const": "audio"
+    },
+    "delivery": {
+      "const": "single_consumer"
+    },
+    "data": {
+      "type": "object",
+      "description": "Payload for bloodbank.v1.audio.transcription.start.",
+      "properties": {
+        "file_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path to the audio file to transcribe."
+        },
+        "transcription_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "description": "Optional caller-assigned transcription id. When null the service MUST generate one and surface it on the resulting started event."
+        },
+        "engine": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Preferred engine ('whisper', 'voxcpm2', 'elevenlabs', ...). Service MAY ignore if not supported."
+        },
+        "engine_model": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Preferred model variant under the engine."
+        },
+        "language": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "BCP-47 language hint (e.g. 'en', 'en-US'). Null means engine-autodetect."
+        },
+        "priority": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "low",
+            "normal",
+            "high",
+            null
+          ],
+          "description": "Queue priority hint. Service MAY honor or ignore."
+        }
+      },
+      "required": [
+        "file_path"
+      ],
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "type",
+    "kind",
+    "domain",
+    "data",
+    "actor",
+    "command_id",
+    "idempotency_key",
+    "delivery"
+  ]
+}

--- a/schemas/bloodbank/v1/audio/transcription.started.v1.json
+++ b/schemas/bloodbank/v1/audio/transcription.started.v1.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://33god.dev/schemas/bloodbank/v1/audio/transcription.started.v1.json",
+  "title": "Audio Transcription Started Event",
+  "description": "A transcription job began. Emitted by the transcription service after it accepts a bloodbank.v1.audio.transcription.start command (or after it picks up a file.received event in autonomous mode). Use ordering_key 'transcription:<transcription_id>' so started/completed/failed for the same job form one bucket. See bloodbank/docs/event-naming.md.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../../../_common/cloudevent_base.v1.json"
+    }
+  ],
+  "properties": {
+    "type": {
+      "const": "bloodbank.v1.audio.transcription.started"
+    },
+    "kind": {
+      "const": "event"
+    },
+    "domain": {
+      "const": "audio"
+    },
+    "data": {
+      "type": "object",
+      "description": "Payload for bloodbank.v1.audio.transcription.started.",
+      "properties": {
+        "transcription_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Unique identifier for this transcription job. Stable across started/completed/failed for the same job. Mirrors envelope.ordering_key bucket."
+        },
+        "file_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path to the audio file being transcribed."
+        },
+        "command_id": {
+          "oneOf": [
+            {
+              "$ref": "../../../_common/types.v1.json#/$defs/uuid"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "command_id of the originating audio.transcription.start command. Null if started autonomously (e.g. watcher-driven without an explicit command)."
+        },
+        "engine": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Transcription engine selected for this job (e.g. 'whisper', 'voxcpm2', 'elevenlabs')."
+        },
+        "engine_model": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Specific model variant under the engine (e.g. 'whisper-large-v3', 'voxcpm2-base')."
+        },
+        "language": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "BCP-47 language hint provided to the engine (e.g. 'en', 'en-US', 'es'). Null means autodetect."
+        }
+      },
+      "required": [
+        "transcription_id",
+        "file_path"
+      ],
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "type",
+    "kind",
+    "domain",
+    "data"
+  ]
+}

--- a/services/agent-hooks/core/validate.py
+++ b/services/agent-hooks/core/validate.py
@@ -55,7 +55,7 @@ SUBJECT_REGEX = re.compile(
 
 ALLOWED_DOMAINS = frozenset({
     # active
-    "conversation", "agent", "llm", "cli", "tool", "system",
+    "conversation", "agent", "llm", "cli", "tool", "system", "audio",
     # reserved (registered but not yet emitted)
     "approval", "workspace", "workflow", "memory",
 })
@@ -69,6 +69,7 @@ ALLOWED_ENTITIES = frozenset({
     "heartbeat",
     "approval_request",
     "worktree", "branch", "diff",
+    "file", "transcription",
 })
 
 EVENT_ACTIONS = frozenset({


### PR DESCRIPTION
## Summary
Implements ticket #226 by moving the dirty-main audio contract work into a proper BMAD ticket branch/PR.

### Changes
- Adds `audio` domain to event naming contract (`docs/event-naming.md`).
- Registers `audio` + `file`/`transcription` in validator allowlists (`services/agent-hooks/core/validate.py`).
- Adds audio schemas:
  - `bloodbank.v1.audio.file.received`
  - `bloodbank.v1.audio.transcription.start`
  - `bloodbank.v1.audio.transcription.started`
  - `bloodbank.v1.audio.transcription.completed`
  - `bloodbank.v1.audio.transcription.failed`

## Verification
- `mise run smoketest:schemas` ✅

## Ticket
- Closes #226
