### PR TITLE
chore(bmad): ignore local issue execution logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ htmlcov/
 _bmad_output/evidence/repo-health-*.json
 _bmad_output/evidence/repo-health-idle-decision-*.json
 _bmad_output/evidence/closeout/*.json
+_bmad_output/issue-*-execution.md
 
 # Local OpenClaw hook workspace artifacts (operator-local; not project source)
 /services/agent-hooks/openclaw/


### PR DESCRIPTION
## Summary
- ignores local `_bmad_output/issue-*-execution.md` logs so operator-local ticket notes do not dirty primary checkout
- keeps BMAD evidence JSON ignore behavior unchanged

## Why
Issue #229 narrowed strict-clean failures down to only untracked local execution logs after main alignment. This makes strict-clean gates resilient to those local-only artifacts.

## Verification
- from primary checkout prior to merge, these files are the only remaining dirt:
  - `_bmad_output/issue-226-execution.md`
  - `_bmad_output/issue-228-execution.md`
  - `_bmad_output/issue-229-execution.md`
- with this ignore rule on main, those paths no longer participate in `git status` dirt checks.

Closes #229
