### PR TITLE
chore(bmad): capture primary checkout edits for strict-clean recovery

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -19,6 +19,7 @@ networks:
 volumes:
   bloodbank-nats-data:
   bloodbank-apicurio-data:
+  bloodbank-postgres-data:
 
 services:
   nats:
@@ -331,6 +332,94 @@ services:
       - "${BLOODBANK_DAPR_CLAUDE_EVENTS_HTTP_PORT:-3503}:3500"
     # No container-level healthcheck (distroless image). Liveness is
     # verified externally via curl :3503/v1.0/healthz.
+    networks:
+      - bloodbank-network
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Candystore - durable Bloodbank event audit trail
+  # ---------------------------------------------------------------------------
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: bloodbank-postgres
+    profiles:
+      - candystore
+    environment:
+      POSTGRES_USER: candystore
+      POSTGRES_PASSWORD: candystore
+      POSTGRES_DB: candystore
+    volumes:
+      - bloodbank-postgres-data:/var/lib/postgresql/data
+      - ../../candystore/migrations:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U candystore"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    networks:
+      - bloodbank-network
+    restart: unless-stopped
+
+  candystore:
+    build:
+      context: ../../candystore
+    container_name: bloodbank-candystore
+    profiles:
+      - candystore
+    environment:
+      APP_PORT: "3001"
+      DATABASE_URL: "postgresql://candystore:candystore@postgres:5432/candystore"
+      SUBSCRIBE_PUBSUB: "bloodbank-pubsub"
+      SUBSCRIBE_TOPIC: "bloodbank.evt.v1.>"
+      SUBSCRIBE_ROUTE: "/events/all"
+    ports:
+      - "${BLOODBANK_CANDYSTORE_PORT:-3603}:3001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:3001/healthz', timeout=3)\"",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    networks:
+      - bloodbank-network
+    restart: unless-stopped
+
+  daprd-candystore:
+    image: daprio/daprd:1.13.0
+    container_name: bloodbank-daprd-candystore
+    profiles:
+      - candystore
+    command:
+      - "./daprd"
+      - "--app-id=bloodbank-candystore"
+      - "--dapr-http-port=3500"
+      - "--dapr-grpc-port=50001"
+      - "--app-port=3001"
+      - "--app-channel-address=candystore"
+      - "--app-protocol=http"
+      - "--resources-path=/components"
+      - "--placement-host-address=dapr-placement:50005"
+      - "--log-level=info"
+    depends_on:
+      nats-init:
+        condition: service_completed_successfully
+      dapr-placement:
+        condition: service_started
+      candystore:
+        condition: service_healthy
+    volumes:
+      - ../../candystore/dapr-components:/components:ro
+    ports:
+      - "${BLOODBANK_DAPR_CANDYSTORE_HTTP_PORT:-3505}:3500"
     networks:
       - bloodbank-network
     restart: unless-stopped

--- a/compose/nats/init.sh
+++ b/compose/nats/init.sh
@@ -3,8 +3,8 @@
 #
 # Reads /work/streams.json and applies each stream definition to the
 # connected NATS server. Idempotent: if a stream already exists with the
-# desired name, this script logs and continues; `nats stream add` returns
-# a non-zero exit when the stream already exists, which we tolerate.
+# desired name, this script reconciles its subject list with streams.json and
+# leaves the existing stream data intact.
 #
 # Environment:
 #   NATS_URL   -- NATS server URL. Default: nats://nats:4222
@@ -46,9 +46,20 @@ apply_stream() {
   max_bytes="$8"
   replicas="$9"
 
-  # If the stream already exists, we consider init a no-op.
   if nats --server="${NATS_URL}" stream info "${name}" >/dev/null 2>&1; then
-    echo "nats-init: stream ${name} already exists, skipping"
+    current_subjects=$(
+      nats --server="${NATS_URL}" stream info "${name}" --json \
+        | jq -r '.config.subjects | join(",")'
+    )
+    if [ "$(normalize_subjects "${current_subjects}")" = "$(normalize_subjects "${subjects}")" ]; then
+      echo "nats-init: stream ${name} already exists with desired subjects, skipping"
+      return 0
+    fi
+
+    echo "nats-init: updating stream ${name} subjects ${current_subjects} -> ${subjects}"
+    nats --server="${NATS_URL}" stream edit "${name}" \
+      --subjects="${subjects}" \
+      --force
     return 0
   fi
 
@@ -74,6 +85,14 @@ apply_stream() {
     --max-bytes="${max_bytes}" \
     --replicas="${replicas}" \
     --defaults
+}
+
+normalize_subjects() {
+  printf '%s\n' "$1" \
+    | tr ',' '\n' \
+    | sed '/^$/d' \
+    | sort \
+    | paste -sd, -
 }
 
 # Extract each stream config and apply it. `jq` is included in nats-box.

--- a/mise.toml
+++ b/mise.toml
@@ -13,12 +13,20 @@ description = "Boot core sandbox (NATS + nats-init only)"
 run = "docker compose --project-name $COMPOSE_PROJECT -f $COMPOSE_FILE up -d nats nats-init"
 
 [tasks."up:all"]
-description = "Boot every compose profile (heartbeat + claude-events + dapr)"
+description = "Boot every compose profile (heartbeat + claude-events + dapr + candystore)"
 run = """
 docker compose --project-name $COMPOSE_PROJECT -f $COMPOSE_FILE \
   --profile heartbeat --profile claude-events \
   --profile dapr-smoketest --profile dapr-subscribe \
-  up -d
+  --profile candystore \
+  up -d --build
+"""
+
+[tasks."up:candystore"]
+description = "Boot candystore profile (postgres + app + daprd)"
+run = """
+docker compose --project-name $COMPOSE_PROJECT -f $COMPOSE_FILE \
+  --profile candystore up -d --build postgres candystore daprd-candystore
 """
 
 [tasks.down]
@@ -27,6 +35,7 @@ run = """
 docker compose --project-name $COMPOSE_PROJECT -f $COMPOSE_FILE \
   --profile heartbeat --profile claude-events \
   --profile dapr-smoketest --profile dapr-subscribe \
+  --profile candystore \
   down -v
 """
 
@@ -267,5 +276,6 @@ run = """
 docker compose --project-name $COMPOSE_PROJECT -f $COMPOSE_FILE \
   --profile heartbeat --profile claude-events \
   --profile dapr-smoketest --profile dapr-subscribe \
+  --profile candystore \
   ps
 """

--- a/services/agent-hooks/copilot/publish.py
+++ b/services/agent-hooks/copilot/publish.py
@@ -22,6 +22,7 @@ Hook → v1 CloudEvents type mapping:
 Unknown hook names are rejected (no auto-translation fallback) since
 arbitrary names cannot satisfy the v1 contract regex.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -52,13 +53,13 @@ COPILOT_ACTOR: dict[str, Any] = {
 
 # Copilot camelCase hook → (v1 CloudEvents type, ordering bucket prefix)
 HOOK_MAP: dict[str, tuple[str, str]] = {
-    "sessionStart":        ("bloodbank.v1.cli.session.started",        "cli_session"),
-    "sessionEnd":          ("bloodbank.v1.cli.session.ended",          "cli_session"),
-    "userPromptSubmitted": ("bloodbank.v1.conversation.turn.started",  "thread"),
-    "preToolUse":          ("bloodbank.v1.tool.tool_call.requested",   "invocation"),
-    "postToolUse":         ("bloodbank.v1.tool.tool_call.completed",   "invocation"),
-    "errorOccurred":       ("bloodbank.v1.agent.invocation.failed",    "invocation"),
-    "agentStop":           ("bloodbank.v1.agent.invocation.completed", "invocation"),
+    "sessionStart": ("bloodbank.v1.cli.session.started", "cli_session"),
+    "sessionEnd": ("bloodbank.v1.cli.session.ended", "cli_session"),
+    "userPromptSubmitted": ("bloodbank.v1.conversation.turn.started", "thread"),
+    "preToolUse": ("bloodbank.v1.tool.tool_call.requested", "invocation"),
+    "postToolUse": ("bloodbank.v1.tool.tool_call.completed", "invocation"),
+    "errorOccurred": ("bloodbank.v1.agent.invocation.failed", "invocation"),
+    "agentStop": ("bloodbank.v1.agent.invocation.completed", "invocation"),
 }
 
 
@@ -79,7 +80,9 @@ def _read_stdin() -> Any:
 
 
 def _log(msg: str) -> None:
-    if os.environ.get("BLOODBANK_DEBUG") == "true" or os.environ.get("BLOODBANK_HOOK_VERBOSE"):
+    if os.environ.get("BLOODBANK_DEBUG") == "true" or os.environ.get(
+        "BLOODBANK_HOOK_VERBOSE"
+    ):
         print(f"[bloodbank-copilot-hook] {msg}", file=sys.stderr)
 
 
@@ -97,7 +100,9 @@ def _tool_call_id(session_id: str, hook_name: str, payload: Any) -> str:
     return hashlib.sha1(seed.encode("utf-8"), usedforsecurity=False).hexdigest()[:32]
 
 
-def _shape_data(ce_type: str, session_id: str, hook_name: str, payload: Any) -> dict[str, Any]:
+def _shape_data(
+    ce_type: str, session_id: str, hook_name: str, payload: Any
+) -> dict[str, Any]:
     """Project the raw Copilot hook payload into the v1 schema's required data shape.
 
     Unknown keys from the hook payload are preserved under ``raw`` so downstream
@@ -126,7 +131,9 @@ def _shape_data(ce_type: str, session_id: str, hook_name: str, payload: Any) -> 
         tool_name = "unknown"
         arguments: dict[str, Any] | None = None
         if isinstance(payload, dict):
-            tool_name = str(payload.get("tool") or payload.get("tool_name") or "unknown")
+            tool_name = str(
+                payload.get("tool") or payload.get("tool_name") or "unknown"
+            )
             args = payload.get("arguments") or payload.get("tool_input")
             if isinstance(args, dict):
                 arguments = args
@@ -140,7 +147,9 @@ def _shape_data(ce_type: str, session_id: str, hook_name: str, payload: Any) -> 
             base["arguments"] = arguments
         if ce_type == "bloodbank.v1.tool.tool_call.completed":
             outcome = "success"
-            if isinstance(payload, dict) and (payload.get("is_error") or payload.get("error")):
+            if isinstance(payload, dict) and (
+                payload.get("is_error") or payload.get("error")
+            ):
                 outcome = "error"
             base["outcome"] = outcome
         return base


### PR DESCRIPTION
## Summary
Ticket-first capture of primary-checkout local edits that were blocking strict-clean pilot gates.

## Changes
- add candystore profile services/tasks wiring in compose + mise
- make `compose/nats/init.sh` reconcile existing stream subjects instead of hard skip
- carry current copilot hook publisher formatting/state from primary checkout

## Verification
- `python3 cli/bb.py doctor`
- `bash ops/smoketest/smoketest-bloodbank-naming.sh`

Refs #233
