### PR TITLE
chore(gitignore): ignore operator-local agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,9 @@ _bmad_output/issue-*-execution.md
 # Repo-local Hermes runtime state (secrets/sessions/logs)
 agents/hermes/runtime/**
 !agents/hermes/runtime/.gitignore
+
+# Local agent scratch/state artifacts (operator-local)
+.agents/
+.codex/
+claudemap-cache.json
+claudemap-maps.json


### PR DESCRIPTION
## Summary
Unblock strict-clean recovery in #233 by ignoring operator-local agent artifacts that should not participate in repo health gates.

## Changes
- ignore `.agents/` scratch directory
- ignore `.codex/` scratch directory
- ignore generated claudemap cache files

## Verification
- `bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh`
- `git check-ignore -v .agents/foo .codex/foo claudemap-cache.json claudemap-maps.json`

Refs #233
