### PR TITLE
docs: codify candystore integration boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,9 @@ alongside each service, using publishers generated from the local
   Bloodbank never invents an envelope shape outside that tree.
 - Sandbox compose project name is `bloodbank`; network is `bloodbank-network`;
   container names are `bloodbank-*`.
+- Candystore is the sibling durable audit service, not a duplicate Bloodbank
+  stack. Bloodbank compose owns the runtime wiring and builds `../../candystore`
+  under the `candystore` profile. See `docs/candystore-integration.md`.
 
 ## Anti-patterns
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ workflows (bootstrap, smoketest, replay, trace).
 ## Architecture
 
 - **Broker:** NATS JetStream. Two durable streams: `BLOODBANK_EVENTS` for
-  immutable `event.*` traffic, `BLOODBANK_COMMANDS` for `command.*` / `reply.*`
+  immutable `bloodbank.evt.v1.*` traffic, `BLOODBANK_COMMANDS` for
+  `bloodbank.cmd.v1.*` / `bloodbank.rpy.v1.*` round-trips.
   round-trips. Topology in [`compose/nats/streams.json`](compose/nats/streams.json).
 - **Runtime:** Dapr sidecars. Pub/sub component fronts NATS via
   [`compose/components/pubsub.yaml`](compose/components/pubsub.yaml). State and
@@ -26,6 +27,10 @@ workflows (bootstrap, smoketest, replay, trace).
   is ever invented outside the schema tree.
 - **Discovery:** EventCatalog. The mount point at `compose/eventcatalog/site` is
   populated from the local schema tree.
+- **Durable audit trail:** Candystore lives in the sibling
+  `../candystore` repository and is run by the `candystore` compose profile.
+  See [`docs/candystore-integration.md`](docs/candystore-integration.md) for the
+  ownership boundary and runtime wiring.
 
 ADR-0001 in the metarepo ratifies these decisions (TBD; not yet committed).
 
@@ -56,7 +61,7 @@ The sandbox compose project is `bloodbank`; everything attaches to the
 
 | Path                 | Contents                                                            |
 |----------------------|---------------------------------------------------------------------|
-| `compose/`           | docker-compose.yml + Dapr/NATS/Apicurio/EventCatalog wiring         |
+| `compose/`           | docker-compose.yml + Dapr/NATS/Apicurio/EventCatalog/Candystore wiring |
 | `cli/`               | `bb` operator CLI (`doctor`, `trace`, `replay`, `emit`)             |
 | `ops/bootstrap/`     | Pre-boot file-presence validator                                    |
 | `ops/smoketest/`     | End-to-end round-trip tests                                         |
@@ -91,7 +96,9 @@ intentional stubs that will be filled in as the operator surfaces land.
 
 ## Conventions
 
-- Subjects: `event.{domain}.{entity}.{action}` and `command.{agent}.{action}`.
+- Subjects: `bloodbank.evt.v1.<domain>.<entity>.<action>`,
+  `bloodbank.cmd.v1.<domain>.<entity>.<action>`, and
+  `bloodbank.rpy.v1.<domain>.<entity>.<action>`.
 - Every envelope carries `correlationid` and `causationid`.
 - Sandbox identifiers all use the `bloodbank` prefix (project, network,
   containers). No version suffix.

--- a/compose/README.md
+++ b/compose/README.md
@@ -1,8 +1,9 @@
 # Bloodbank Compose sandbox
 
-This directory holds the first self-hosted scaffold for the 33GOD event
-platform. It is a **sandbox**, not production wiring. No real event traffic
-is published through Dapr or NATS yet; that is planned in later tickets.
+This directory holds the self-hosted sandbox for the 33GOD event platform. It
+is local runtime wiring, not production traffic. Profiles now carry real local
+event traffic through NATS JetStream and Dapr sidecars for smoke tests,
+heartbeat, Claude-event capture, and Candystore audit storage.
 
 Architectural source of truth:
 
@@ -16,7 +17,8 @@ Architectural source of truth:
 - Dapr app ID prefix: `bloodbank-`
 - NATS events stream: `BLOODBANK_EVENTS`
 - NATS commands stream: `BLOODBANK_COMMANDS`
-- NATS subject prefixes: `event.`, `command.`, `reply.`
+- NATS subject prefixes: `bloodbank.evt.v1.`, `bloodbank.cmd.v1.`,
+  `bloodbank.rpy.v1.`
 - Env var prefix: `BLOODBANK_`
 
 ## Layout
@@ -40,21 +42,27 @@ compose/
 
 ## Services
 
-| Service             | Image                                      | Host port(s)                        | Purpose                                         |
-|---------------------|--------------------------------------------|-------------------------------------|-------------------------------------------------|
-| `nats`              | `nats:2.10-alpine`                         | `4222` (client), `8222` (monitor)   | JetStream broker (`BLOODBANK_EVENTS` + `_COMMANDS`) |
-| `nats-init`         | `natsio/nats-box:0.14.5`                   | -                                   | Oneshot: applies `nats/streams.json` to NATS on each `up` |
-| `dapr-placement`    | `daprio/dapr:1.13.0`                       | `50005`                             | Dapr actor placement for future sidecars        |
-| `apicurio-registry` | `apicurio/apicurio-registry:3.0.6`         | `8080`                              | Runtime schema registry (read side)             |
-| `eventcatalog`      | `quay.io/eventcatalog/eventcatalog:2.11.1` | `3000`                              | Human/agent event discovery UI                  |
+| Service             | Profile(s)        | Host port(s)                        | Purpose                                         |
+|---------------------|-------------------|-------------------------------------|-------------------------------------------------|
+| `nats`              | default           | `4222` (client), `8222` (monitor)   | JetStream broker (`BLOODBANK_EVENTS` + `_COMMANDS`) |
+| `nats-init`         | default           | -                                   | Oneshot: applies `nats/streams.json` to NATS on each `up` |
+| `dapr-placement`    | default           | `50005`                             | Dapr actor placement for sidecars               |
+| `apicurio-registry` | default           | `8080`                              | Runtime schema registry (read side)             |
+| `eventcatalog`      | default           | `3000`                              | Human/agent event discovery UI                  |
+| `echo-sub` + sidecar | `dapr-subscribe` | `3301`, `3501`                      | Minimal Dapr subscribe smoke app                |
+| `heartbeat-*`       | `heartbeat`       | `3601`, `3502`                      | Reference heartbeat producer/consumer path      |
+| `claude-events-*`   | `claude-events`   | `3602`, `3503`                      | Host hook event recorder path                   |
+| `postgres`          | `candystore`      | internal                            | Candystore PostgreSQL database                  |
+| `candystore` + sidecar | `candystore`   | `3603`, `3505`                      | Durable Bloodbank event audit trail             |
 
 All ports can be overridden by `BLOODBANK_*_PORT` env vars without editing
 the compose file (see the service definitions for exact names).
 
-Dapr sidecars are intentionally **not** defined yet. When V3-005 onward adds
-app services, each sidecar must mount `./components` read-only so that
-`bloodbank-pubsub`, `bloodbank-statestore`, and `bloodbank-secretstore`
-are loaded.
+Dapr sidecars are defined per profile. Most sidecars mount `./components`
+read-only. Candystore is the exception: its sidecar mounts
+`../../candystore/dapr-components` so the audit consumer gets its own durable
+JetStream consumer settings while still using the shared `bloodbank-pubsub`
+component name.
 
 ## Image version caveat
 
@@ -103,12 +111,12 @@ docker compose \
 
 ## Dapr component manifests
 
-Each file in `components/` is loaded by a Dapr sidecar once app services land.
+Each file in `components/` is loaded by the Bloodbank-owned Dapr sidecars.
 
 - **`pubsub.yaml`** — `bloodbank-pubsub`; `pubsub.jetstream` targeting
   `nats://nats:4222`, events stream `BLOODBANK_EVENTS`, events subject
-  scope `event.>`. Commands and replies are handled by a future command
-  bus component rather than the pub/sub abstraction.
+  scope `bloodbank.evt.v1.>`. Commands and replies are carried by
+  `BLOODBANK_COMMANDS` on `bloodbank.cmd.v1.>` and `bloodbank.rpy.v1.>`.
 - **`statestore.yaml`** — `bloodbank-statestore`; `state.in-memory` is
   the scaffold default. See "State store tradeoff" below.
 - **`secretstore.yaml`** — `bloodbank-secretstore`;
@@ -128,10 +136,20 @@ only; no code change is required.
 
 ## NATS topology
 
-See `nats/README.md` for subject conventions (`event.<domain>.<entity>.<action>`,
-`command.<target>.<verb>`, `reply.<target>.<verb>`), retention posture, and
-replay metadata header names. See `nats/streams.json` for the machine-readable
-stream definitions.
+See `nats/README.md` for subject conventions
+(`bloodbank.evt.v1.<domain>.<entity>.<action>`,
+`bloodbank.cmd.v1.<domain>.<entity>.<action>`, and
+`bloodbank.rpy.v1.<domain>.<entity>.<action>`), retention posture, and replay
+metadata header names. See `nats/streams.json` for the machine-readable stream
+definitions.
+
+## Candystore
+
+The `candystore` profile builds and runs the sibling `../../candystore`
+repository as the durable Bloodbank event audit trail. The compose stack knows
+about Candystore; Candystore itself remains a separate service repo. The
+runtime boundary, per-service Dapr component rationale, and verification probes
+are documented in [`../docs/candystore-integration.md`](../docs/candystore-integration.md).
 
 ### Stream initialization
 

--- a/docs/candystore-integration.md
+++ b/docs/candystore-integration.md
@@ -1,0 +1,90 @@
+# Candystore Integration
+
+Candystore is the durable audit trail for Bloodbank events. It is a sibling
+repository, not a duplicate Bloodbank stack:
+
+- `~/code/33GOD/bloodbank` owns the event backbone, schemas, naming contract,
+  NATS JetStream topology, Dapr component conventions, and the compose sandbox.
+- `~/code/33GOD/candystore` owns the audit application: HTTP ingestion/API,
+  PostgreSQL migrations, React UI, and its per-service Dapr pub/sub component.
+- `bloodbank/compose/docker-compose.yml` is the local runtime bridge. The
+  `candystore` profile builds `../../candystore`, runs `bloodbank-candystore`,
+  attaches it to `bloodbank-network`, and gives it Postgres plus a Dapr sidecar.
+
+## Runtime Path
+
+The local event flow is:
+
+1. Bloodbank producers publish CloudEvents to NATS/Dapr on subjects matching
+   `bloodbank.evt.v1.>`.
+2. `BLOODBANK_EVENTS` stores those messages in NATS JetStream.
+3. `bloodbank-daprd-candystore` mounts
+   `../../candystore/dapr-components:/components:ro`.
+4. Dapr calls `GET http://candystore:3001/dapr/subscribe`.
+5. Candystore declares subscription:
+   `pubsubname=bloodbank-pubsub`, `topic=bloodbank.evt.v1.>`,
+   `route=/events/all`.
+6. Dapr POSTs matching events to `http://candystore:3001/events/all`.
+7. Candystore persists the full envelope in PostgreSQL and exposes query/UI
+   routes on the app port.
+
+On the host, the default ports are:
+
+- Candystore app/API: `http://127.0.0.1:3603`
+- Candystore Dapr sidecar: `http://127.0.0.1:3505`
+
+Quick probes:
+
+```bash
+curl -fsS http://127.0.0.1:3603/dapr/subscribe
+curl -fsS http://127.0.0.1:3505/v1.0/metadata
+curl -fsS 'http://127.0.0.1:3603/events?limit=3'
+```
+
+## Component Ownership
+
+There are intentionally two Dapr pub/sub manifests with the same component
+name:
+
+- `bloodbank/compose/components/pubsub.yaml` is the shared sandbox component.
+  It leaves `durableName` unset so multiple sidecars with different filters do
+  not collide on one JetStream durable consumer.
+- `candystore/dapr-components/pubsub.yaml` is Candystore-specific. It still
+  uses `metadata.name: bloodbank-pubsub` so the app subscription matches, but it
+  sets `durableName: candystore-events` and `queueGroupName: candystore` because
+  Candystore is the durable audit consumer.
+
+Do not fold Candystore into Bloodbank just to simplify the compose file. The
+clean boundary is: Bloodbank owns event transport and contracts; Candystore owns
+durable storage and audit UX.
+
+## Envelope Contract
+
+Candystore is intentionally strict. Any event delivered through this path must
+conform to `docs/event-naming.md` and include the canonical top-level fields
+required by Bloodbank:
+
+- `type`: `bloodbank.v1.<domain>.<entity>.<action>`
+- `subject`: `bloodbank.<evt|cmd|rpy>.v1.<domain>.<entity>.<action>`
+- `domain`: must match the third token of `type`
+- `kind`: `event`, `command`, or `reply`
+- `correlationid` and `causationid`
+- `producer`, `service`, `actor`, and `data`
+- `ordering_key` for events
+
+Do not emit snake_case CloudEvents extension aliases such as `correlation_id` or
+`causation_id`. Those are not the Bloodbank contract and will not satisfy
+Candystore.
+
+## Known Drift Pattern
+
+Hermes PM runtime consumers generated from
+`hermes-agent-template/runtime-scaffold/bloodbank-consumer.py` have historically
+announced online/offline presence with a hand-rolled envelope that is missing
+required fields such as `domain`, `subject`, and `ordering_key`, and uses
+`correlation_id`/`causation_id` instead of `correlationid`/`causationid`.
+
+When `bloodbank-daprd-candystore` replays those messages, Candystore returns
+`400` and Dapr retries the JetStream message. Fix the generator/template and
+then backfill existing official PM runtimes; do not patch only the generated
+file unless the template is fixed too.


### PR DESCRIPTION
## Summary
Classifies the intentional portion of #237 docs drift into a scoped docs PR.

## Included
- AGENTS.md candystore boundary note
- README.md subject convention + candystore boundary clarifications
- compose/README.md runtime profile/subject/candystore documentation refresh
- new docs/candystore-integration.md integration contract

## Excluded
- `docs/delegations/` remains local/untracked operator artifact and is intentionally not part of this PR.

## Verification
- `python3 cli/bb.py doctor`

Refs #237
