### PR TITLE
feat(contract): formalize agent invocation.start command schema

### DIFF
--- a/agents/hermes/pm/role.yaml
+++ b/agents/hermes/pm/role.yaml
@@ -34,7 +34,7 @@ plane:
 bloodbank:
   subscribe:
     - "bloodbank.evt.v1.repo.bloodbank.>"
-    - "bloodbank.cmd.v1.agent.bloodbank-pm.>"
+    - "bloodbank.cmd.v1.agent.invocation.start"
   producer: "hermes-agent:bloodbank-pm"
 
 # Runtime repo (git-tracked HERMES_HOME, auto-checkpointed).

--- a/compose/nats/README.md
+++ b/compose/nats/README.md
@@ -49,7 +49,7 @@ Past-tense action. Examples:
 
 Imperative action. Examples:
 
-- `bloodbank.cmd.v1.agent.invocation.start`
+- `bloodbank.cmd.v1.agent.invocation.start` (canonical PM->agent invocation command; route via `data.target_agent_id`)
 - `bloodbank.cmd.v1.cli.process.spawn`
 
 ### Replies: `bloodbank.rpy.v1.<domain>.<entity>.<action>`

--- a/docs/event-naming.md
+++ b/docs/event-naming.md
@@ -120,6 +120,15 @@ type     bloodbank.v1.agent.invocation.start
 subject  bloodbank.cmd.v1.agent.invocation.start          # command
 ```
 
+Canonical PM->agent dispatch contract:
+
+- Command envelope type: `bloodbank.v1.agent.invocation.start`
+- Command subject: `bloodbank.cmd.v1.agent.invocation.start`
+- Target routing key: `data.target_agent_id`
+
+Routers and consumers MUST dispatch this command by `data.target_agent_id`
+rather than encoding the target agent in the subject path.
+
 The legacy `event.>` / `command.>` / `reply.>` subject prefixes are
 **deprecated** and will be removed when the migration completes (§16).
 
@@ -369,6 +378,7 @@ bloodbank/schemas/
       turn.completed.v1.json
       message.appended.v1.json
     agent/
+      invocation.start.v1.json
       invocation.started.v1.json
       invocation.completed.v1.json
       invocation.failed.v1.json

--- a/schemas/bloodbank/v1/agent/invocation.start.v1.json
+++ b/schemas/bloodbank/v1/agent/invocation.start.v1.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://33god.dev/schemas/bloodbank/v1/agent/invocation.start.v1.json",
+  "title": "Agent Invocation Start Command",
+  "description": "Canonical PM->agent invocation command. Producers publish this envelope on bloodbank.cmd.v1.agent.invocation.start and routers/consumers dispatch using data.target_agent_id.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../../../_common/cloudevent_base.v1.json"
+    }
+  ],
+  "properties": {
+    "type": {
+      "const": "bloodbank.v1.agent.invocation.start"
+    },
+    "kind": {
+      "const": "command"
+    },
+    "domain": {
+      "const": "agent"
+    },
+    "delivery": {
+      "const": "single_consumer"
+    },
+    "data": {
+      "type": "object",
+      "description": "Payload for bloodbank.v1.agent.invocation.start.",
+      "properties": {
+        "target_agent_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Routing key identifying which agent should execute the invocation."
+        },
+        "thread_id": {
+          "type": ["string", "null"],
+          "description": "Optional existing thread identifier for continuation."
+        },
+        "turn_id": {
+          "type": ["string", "null"],
+          "description": "Optional caller-assigned turn identifier."
+        },
+        "prompt": {
+          "type": ["string", "null"],
+          "description": "Prompt/content for the target agent to execute."
+        },
+        "context": {
+          "type": ["object", "null"],
+          "description": "Optional structured context for the target agent invocation.",
+          "additionalProperties": true
+        }
+      },
+      "required": ["target_agent_id"],
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "type",
+    "kind",
+    "domain",
+    "data",
+    "actor",
+    "command_id",
+    "idempotency_key",
+    "delivery"
+  ]
+}


### PR DESCRIPTION
## Summary
Classify and formalize the untracked `invocation.start` schema artifact into the canonical Bloodbank contract.

## Changes
- add canonical command schema: `schemas/bloodbank/v1/agent/invocation.start.v1.json`
- align PM runtime subscription subject in `agents/hermes/pm/role.yaml`
- document canonical PM->agent invocation routing contract in `docs/event-naming.md`
- note canonical command usage in `compose/nats/README.md`

## Verification
- `python3 cli/bb.py doctor`
- `bash scripts/validate_schemas.sh`
- `bash ops/smoketest/smoketest-schema-contract-consistency.sh`
- `bash ops/smoketest/smoketest-bloodbank-naming.sh`

Refs #240
