### PR TITLE
fix: reconcile Hermes PM runtime drift and harden local defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ _bmad_output/evidence/repo-health-*.json
 _bmad_output/evidence/repo-health-idle-decision-*.json
 _bmad_output/evidence/closeout/*.json
 _bmad_output/issue-*-execution.md
+agents/hermes/pm/.runtime-scaffold/
 
 # Local OpenClaw hook workspace artifacts (operator-local; not project source)
 /services/agent-hooks/openclaw/

--- a/agents/hermes/pm/.scripts/_lib.sh
+++ b/agents/hermes/pm/.scripts/_lib.sh
@@ -87,11 +87,22 @@ mark_done() {
   touch "$ROLE_DIR/.scripts/.done-$1"
 }
 
+# Fleet source-of-truth (shared across all wrappers/provisioners)
+FLEET_ENV="${HERMES_FLEET_ENV:-$HOME/.hermes/fleet.env}"
+if [[ -f "$FLEET_ENV" ]]; then
+  # shellcheck disable=SC1090
+  source "$FLEET_ENV"
+fi
+
 # Tools we expect on the host
-HERMES_BIN="${HERMES_BIN:-/home/delorenj/code/hermes-agent/.venv/bin/hermes}"
-HERMES_AGENT_REPO="${HERMES_AGENT_REPO:-/home/delorenj/code/hermes-agent}"
-RUNTIME_SCAFFOLD_DIR="${RUNTIME_SCAFFOLD_DIR:-/home/delorenj/code/hermes-agent-template/runtime-scaffold}"
-REGISTRY_FILE="${REGISTRY_FILE:-$HOME/.hermes/agents-registry.yaml}"
+HERMES_BIN="${HERMES_BIN:-${HERMES_FLEET_BIN:-/home/delorenj/code/hermes-agent/.venv/bin/hermes}}"
+HERMES_AGENT_REPO="${HERMES_AGENT_REPO:-${HERMES_FLEET_REPO:-/home/delorenj/code/hermes-agent}}"
+# Prefer a scaffold vendored into this agent directory; fall back to legacy template path.
+RUNTIME_SCAFFOLD_DIR="${RUNTIME_SCAFFOLD_DIR:-$ROLE_DIR/.runtime-scaffold}"
+if [[ ! -d "$RUNTIME_SCAFFOLD_DIR" ]]; then
+  RUNTIME_SCAFFOLD_DIR="${HERMES_TEMPLATE_RUNTIME_SCAFFOLD:-/home/delorenj/code/hermes-agent-template/runtime-scaffold}"
+fi
+REGISTRY_FILE="${REGISTRY_FILE:-${HERMES_FLEET_REGISTRY_FILE:-$HOME/.hermes/agents-registry.yaml}}"
 
 # Bloodbank / NATS
 BLOODBANK_NATS_HOST="${BLOODBANK_NATS_HOST:-127.0.0.1}"
@@ -106,7 +117,7 @@ CF_API="${CF_API:-https://api.cloudflare.com/client/v4}"
 CF_ZONE_DELO_SH="${CF_ZONE_DELO_SH:-eabc163cde3e31680f10fc313aecdda3}"
 CF_ACCOUNT_ID="${CF_ACCOUNT_ID:-${CLOUDFLARE_ACCOUNT_ID:-}}"
 
-export HERMES_BIN HERMES_AGENT_REPO RUNTIME_SCAFFOLD_DIR REGISTRY_FILE \
+export FLEET_ENV HERMES_BIN HERMES_AGENT_REPO RUNTIME_SCAFFOLD_DIR REGISTRY_FILE \
        BLOODBANK_NATS_HOST BLOODBANK_NATS_PORT \
        PLANE_BASE PLANE_API_KEY \
        CF_API CF_ZONE_DELO_SH CF_ACCOUNT_ID

--- a/agents/hermes/pm/hermes
+++ b/agents/hermes/pm/hermes
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
-# Launcher for bloodbank-pm.  Resolves HERMES_HOME to the runtime submodule
-# and execs the global hermes binary.
-
+# Launcher for bloodbank-pm. Resolves HERMES_HOME to runtime and execs shared fleet Hermes.
 set -euo pipefail
 
 ROLE_DIR="$(cd "$(dirname "$0")" && pwd)"
 HERMES_HOME="$ROLE_DIR/runtime"
 
-HERMES_BIN="${HERMES_BIN:-/home/delorenj/code/hermes-agent/.venv/bin/hermes}"
+FLEET_ENV="${HERMES_FLEET_ENV:-$HOME/.hermes/fleet.env}"
+if [[ -f "$FLEET_ENV" ]]; then
+  # shellcheck disable=SC1090
+  source "$FLEET_ENV"
+fi
+
+HERMES_BIN="${HERMES_BIN:-${HERMES_FLEET_BIN:-/home/delorenj/code/hermes-agent/.venv/bin/hermes}}"
 
 if [[ ! -d "$HERMES_HOME" ]]; then
   echo "hermes: runtime submodule not initialized at $HERMES_HOME" >&2
-  echo "  fix:  git submodule update --init --recursive" >&2
+  echo "  fix: git submodule update --init --recursive" >&2
   exit 1
 fi
 
 if [[ ! -x "$HERMES_BIN" ]]; then
   echo "hermes: binary not executable at $HERMES_BIN" >&2
-  echo "  set HERMES_BIN, or activate the hermes-agent venv first." >&2
+  echo "  set HERMES_BIN or HERMES_FLEET_BIN (in $FLEET_ENV) to the shared Hermes binary." >&2
   exit 1
 fi
 
-exec env HERMES_HOME="$HERMES_HOME" "$HERMES_BIN" "$@"
+exec env HERMES_HOME="$HERMES_HOME" HERMES_FLEET_ENV="$FLEET_ENV" "$HERMES_BIN" "$@"

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -375,7 +375,7 @@ services:
       SUBSCRIBE_TOPIC: "bloodbank.evt.v1.>"
       SUBSCRIBE_ROUTE: "/events/all"
     ports:
-      - "${BLOODBANK_CANDYSTORE_PORT:-3603}:3001"
+      - "127.0.0.1:${BLOODBANK_CANDYSTORE_PORT:-3603}:3001"
     depends_on:
       postgres:
         condition: service_healthy
@@ -419,7 +419,7 @@ services:
     volumes:
       - ../../candystore/dapr-components:/components:ro
     ports:
-      - "${BLOODBANK_DAPR_CANDYSTORE_HTTP_PORT:-3505}:3500"
+      - "127.0.0.1:${BLOODBANK_DAPR_CANDYSTORE_HTTP_PORT:-3505}:3500"
     networks:
       - bloodbank-network
     restart: unless-stopped


### PR DESCRIPTION
## Summary
Reconciles unticketed Hermes PM drift under issue #242 while preserving strict-clean BMAD intent.

## Changes
- Adopt fleet-env sourced Hermes launcher defaults in `agents/hermes/pm/hermes`
- Align provisioning helper defaults/fallbacks in `agents/hermes/pm/.scripts/_lib.sh`
- Restrict Candystore and Dapr Candystore host bindings to `127.0.0.1`
- Ignore local runtime scaffold artifacts to prevent untracked drift:
  - `agents/hermes/pm/.runtime-scaffold/`

## Explicit drop decisions
- No submodule gitlink update for `agents/hermes/pm/runtime` (remains pinned at `83526f7`)

## Verification
- `bash -n agents/hermes/pm/hermes agents/hermes/pm/.scripts/_lib.sh`
- `git submodule status --recursive` confirms runtime pinned to `83526f7`

Closes #242
