### PR TITLE
fix: precheck runtime submodule drift in repo-health pilot step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ alongside each service, using publishers generated from the local
 - For backup-first canonical alignment, use `mise run bmad:align-main-with-backup -- --repo <path>` (read-only) then rerun with `--apply` only after review.
 - After successful alignment verification window, run `mise run bmad:recovery-artifact-cleanup -- --repo <path>` (dry-run) before any cleanup apply; use `--min-bundle-age-hours` to protect fresh bundles.
 - For persistent submodule gitlink drift (e.g., Hermes PM runtime), run `mise run bmad:reconcile-submodule-drift -- --repo <path>` for diagnostics first, then rerun with `--apply` only when the helper reports no non-drift worktree edits. The helper now retries with a forced checkout for the known runtime `state.db` overwrite blocker on `agents/hermes/pm/runtime`.
-- `repo-health:pilot-step` may auto-heal strict-gate failures by applying the submodule drift helper once (`DRIFT_AUTOHEAL_ON_STRICT_FAIL=1` default); disable with `DRIFT_AUTOHEAL_ON_STRICT_FAIL=0` when manual intervention is desired.
+- `repo-health:pilot-step` may run submodule drift auto-heal in two places: a precheck pass (`DRIFT_AUTOHEAL_PRECHECK=1`, default) and a strict-failure retry pass (`DRIFT_AUTOHEAL_ON_STRICT_FAIL=1`, default). Disable either flag (`=0`) when manual intervention is desired.
 - `bmad:pr-merge-safe` now attempts safe post-merge reconciliation by default; use `--no-reconcile-main` only when you explicitly need to defer reconciliation.
 - For quick cleanup-status review across closeout artifacts, use `mise run bmad:closeout-cleanup-summary`.
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.

--- a/ops/repo-health/pilot_step.sh
+++ b/ops/repo-health/pilot_step.sh
@@ -11,6 +11,7 @@ INTERVAL_MINUTES="${INTERVAL_MINUTES:-60}"
 KEEP="${KEEP:-8}"
 REPORT="${REPORT:-1}"
 DRIFT_AUTOHEAL_ON_STRICT_FAIL="${DRIFT_AUTOHEAL_ON_STRICT_FAIL:-1}"
+DRIFT_AUTOHEAL_PRECHECK="${DRIFT_AUTOHEAL_PRECHECK:-1}"
 
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 DECISION_OUT="_bmad_output/evidence/repo-health-idle-decision-${TS}.json"
@@ -63,6 +64,21 @@ print('1' if d.get('should_capture_full') else '0')
 PY
 } )"
 
+run_precheck_autoheal() {
+  if [[ "$DRIFT_AUTOHEAL_PRECHECK" != "1" ]]; then
+    return 0
+  fi
+
+  echo "repo-health:precheck attempting submodule drift auto-heal"
+  if python3 ops/bmad/reconcile_submodule_gitlink_drift.py --repo . --apply >/dev/null; then
+    echo "repo-health:precheck drift auto-heal complete"
+    return 0
+  fi
+
+  echo "repo-health:precheck auto-heal skipped (non-main branch or non-drift edits present)"
+  return 0
+}
+
 run_strict_with_autoheal() {
   if mise run repo-health:strict; then
     return 0
@@ -82,6 +98,9 @@ run_strict_with_autoheal() {
   echo "repo-health:strict drift auto-heal applied; retrying strict gate"
   mise run repo-health:strict
 }
+
+# Opportunistically reconcile known drift pattern before strict gate.
+run_precheck_autoheal
 
 # Always run strict gate for repo safety and liveness evidence in logs.
 run_strict_with_autoheal


### PR DESCRIPTION
## Summary
Harden `repo-health:pilot-step` against recurring runtime submodule drift by adding a proactive precheck auto-heal pass before strict gate execution.

## Changes
- `ops/repo-health/pilot_step.sh`
  - add `DRIFT_AUTOHEAL_PRECHECK` (default `1`)
  - run precheck drift reconcile attempt before strict gate
  - keep existing strict-failure auto-heal fallback (`DRIFT_AUTOHEAL_ON_STRICT_FAIL`)
- `AGENTS.md`
  - document both auto-heal toggles and behavior

## Verification
- `bash -n ops/repo-health/pilot_step.sh`
- `mise run smoketest:bmad-repo-health-pilot-step-autoheal`

Closes #257
