### PR TITLE
fix: suppress hermes runtime submodule drift via ignore=all policy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "agents/hermes/pm/runtime"]
 	path = agents/hermes/pm/runtime
 	url = git@github.com:delorenj/agent-hm-bloodbank-pm.git
-	ignore = dirty
+	ignore = all

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ alongside each service, using publishers generated from the local
 - Runtime closeout evidence JSONs under `_bmad_output/evidence/closeout/` are operator-generated artifacts and intentionally git-ignored.
 - If primary checkout is dirty/behind, use the dedicated clean-worktree automation path in `ops/bmad/clean-worktree-automation.md` (do not stash/discard unknown local changes).
 - Local OpenClaw hook scratch path (`services/agent-hooks/openclaw/`) is intentionally treated as operator-local and excluded from repo tracking.
-- Hermes PM runtime state under `agents/hermes/pm/runtime/` is operator-local; only intentional scaffold/docs should be tracked, and `.gitmodules` should keep `submodule.agents/hermes/pm/runtime.ignore=dirty` so runtime-local tracked-file edits do not dirty the primary checkout.
+- Hermes PM runtime state under `agents/hermes/pm/runtime/` is operator-local; only intentional scaffold/docs should be tracked, and `.gitmodules` should keep `submodule.agents/hermes/pm/runtime.ignore=all` so runtime-local gitlink movement does not dirty the primary checkout.
 - Keep BMAD artifacts concise and ticket-scoped; avoid process bloat.
 
 ## Conventions

--- a/cli/bb.py
+++ b/cli/bb.py
@@ -280,6 +280,15 @@ def _git_ref_path_exists(root: Path, ref: str, rel_path: str) -> bool:
     return rc == 0
 
 
+def _submodule_ignore_mode(root: Path, path: str) -> str:
+    """Return the configured .gitmodules ignore mode for a submodule path."""
+    key = f"submodule.{path}.ignore"
+    rc, out, _ = _run(root, "git", "config", "-f", ".gitmodules", "--get", key)
+    if rc != 0:
+        return ""
+    return out.strip().lower()
+
+
 def _collect_submodule_gitlink_drifts(root: Path) -> tuple[list[dict[str, str]], str | None]:
     """Return gitlink drift entries for submodules (marker '+' in status output)."""
     rc, out, err = _run(root, "git", "submodule", "status", "--recursive")
@@ -302,6 +311,9 @@ def _collect_submodule_gitlink_drifts(root: Path) -> tuple[list[dict[str, str]],
         current_commit = payload[0]
         path = payload[1]
         detail = " ".join(payload[2:]).strip()
+
+        if _submodule_ignore_mode(root, path) == "all":
+            continue
 
         recorded_commit = ""
         rc_tree, tree_out, _ = _run(root, "git", "ls-tree", "HEAD", path)

--- a/ops/smoketest/smoketest-hermes-runtime-hygiene.sh
+++ b/ops/smoketest/smoketest-hermes-runtime-hygiene.sh
@@ -32,8 +32,8 @@ if git check-ignore -q "agents/hermes/README.md"; then
 fi
 
 pm_runtime_ignore="$(git config -f .gitmodules --get submodule.agents/hermes/pm/runtime.ignore || true)"
-if [[ "$pm_runtime_ignore" != "dirty" ]]; then
-  echo "agents/hermes/pm/runtime submodule must set ignore=dirty in .gitmodules" >&2
+if [[ "$pm_runtime_ignore" != "all" ]]; then
+  echo "agents/hermes/pm/runtime submodule must set ignore=all in .gitmodules" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Implements the issue-259 policy fix candidate to stop Hermes PM runtime gitlink churn from dirtying repo health when runtime is intentionally operator-local.

### Changes
- `.gitmodules`
  - set `submodule.agents/hermes/pm/runtime.ignore=all`
- `cli/bb.py`
  - repo-health drift collector now suppresses `+` submodule drift entries when `.gitmodules` declares `ignore=all` for that submodule path
- `ops/smoketest/smoketest-hermes-runtime-hygiene.sh`
  - enforce `ignore=all` policy
- `AGENTS.md`
  - policy note updated to `ignore=all`

## Why
Issue #259 reproduces between cycles because Hermes runtime checkpoints advance the runtime submodule HEAD. `ignore=dirty` does not suppress gitlink commit movement from `git status`, so strict-clean is repeatedly violated before auto-heal runs.

`ignore=all` + repo-health policy-aware suppression for that submodule path keeps `main` clean continuously while preserving explicit policy at `.gitmodules` level.

## Validation
- `bash ops/smoketest/smoketest-hermes-runtime-hygiene.sh` ✅
- `bash ops/smoketest/smoketest-bmad-repo-health-helper-availability.sh` ✅
- Synthetic drift experiment (issue log + closeout evidence)

## Evidence
- `_bmad_output/evidence/closeout/issue-259-policy-step-20260531T014546Z.json`
- `_bmad_output/issue-259-execution.md`

Refs #259
