### PR TITLE
fix(repo-health): gate precheck auto-heal on actual drift

### DIFF
--- a/ops/repo-health/pilot_step.sh
+++ b/ops/repo-health/pilot_step.sh
@@ -69,7 +69,15 @@ run_precheck_autoheal() {
     return 0
   fi
 
-  echo "repo-health:precheck attempting submodule drift auto-heal"
+  local drift_count
+  drift_count="$({ python3 ops/bmad/reconcile_submodule_gitlink_drift.py --repo . | python3 -c 'import json,sys; print(json.load(sys.stdin).get("drift_count", 0))'; } 2>/dev/null || echo 0)"
+
+  if [[ "$drift_count" == "0" ]]; then
+    echo "repo-health:precheck no submodule drift detected"
+    return 0
+  fi
+
+  echo "repo-health:precheck drift detected (${drift_count}); attempting auto-heal"
   if python3 ops/bmad/reconcile_submodule_gitlink_drift.py --repo . --apply >/dev/null; then
     echo "repo-health:precheck drift auto-heal complete"
     return 0


### PR DESCRIPTION
## Summary
This tightens pilot precheck logging/behavior so we only run submodule drift auto-heal when drift actually exists.

Previously precheck always logged an "attempting ... complete" sequence even when `drift_count=0`, which created false recurrence signals in pilot-loop evidence.

## Changes
- `ops/repo-health/pilot_step.sh`
  - evaluate drift count first via `reconcile_submodule_gitlink_drift.py --repo .`
  - if `drift_count == 0`: log `repo-health:precheck no submodule drift detected` and skip apply
  - if drift exists: run apply path and keep existing recovery behavior

## Validation
- `mise run repo-health:pilot-step`
  - observed `repo-health:precheck no submodule drift detected`
  - strict gate passed clean (`worktree_dirty: false`, `submodule_gitlink_drifts: 0`)

Refs #261
