### PR TITLE
feat(repo-health): capture runtime drift context before auto-heal

### DIFF
--- a/ops/repo-health/pilot_step.sh
+++ b/ops/repo-health/pilot_step.sh
@@ -64,6 +64,56 @@ print('1' if d.get('should_capture_full') else '0')
 PY
 } )"
 
+capture_runtime_drift_context() {
+  local ts out
+  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+  out="_bmad_output/evidence/runtime-drift-context-${ts}.json"
+
+  python3 - "$out" <<'PY'
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+out = Path(sys.argv[1])
+out.parent.mkdir(parents=True, exist_ok=True)
+runtime = Path("agents/hermes/pm/runtime")
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> dict[str, object]:
+    cp = subprocess.run(cmd, cwd=str(cwd) if cwd else None, text=True, capture_output=True)
+    return {
+        "cmd": " ".join(cmd),
+        "code": cp.returncode,
+        "stdout": cp.stdout.strip(),
+        "stderr": cp.stderr.strip(),
+    }
+
+payload: dict[str, object] = {
+    "captured_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+    "runtime_path": str(runtime),
+    "runtime_exists": runtime.exists(),
+}
+
+if runtime.exists():
+    payload["runtime_probe"] = {
+        "head": run(["git", "rev-parse", "HEAD"], cwd=runtime),
+        "status": run(["git", "status", "--short", "--branch"], cwd=runtime),
+        "last_commit": run(["git", "log", "-1", "--pretty=format:%H %cI %an %s"], cwd=runtime),
+        "recent_reflog": run(["git", "reflog", "-10", "--date=iso"], cwd=runtime),
+    }
+
+payload["superproject_probe"] = {
+    "submodule_status": run(["git", "submodule", "status", "--recursive"]),
+    "git_status": run(["git", "status", "--short", "--branch"]),
+}
+
+out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+print(out)
+PY
+}
+
 run_precheck_autoheal() {
   if [[ "$DRIFT_AUTOHEAL_PRECHECK" != "1" ]]; then
     return 0
@@ -76,6 +126,9 @@ run_precheck_autoheal() {
     echo "repo-health:precheck no submodule drift detected"
     return 0
   fi
+
+  echo "repo-health:precheck drift detected (${drift_count}); capturing context"
+  capture_runtime_drift_context
 
   echo "repo-health:precheck drift detected (${drift_count}); attempting auto-heal"
   if python3 ops/bmad/reconcile_submodule_gitlink_drift.py --repo . --apply >/dev/null; then


### PR DESCRIPTION
## Summary
Adds ticket-scoped instrumentation for issue #261 so recurring runtime submodule drift has actionable forensic context.

## Changes
- `ops/repo-health/pilot_step.sh`
  - adds `capture_runtime_drift_context()` helper
  - when precheck sees drift (`drift_count > 0`), captures:
    - runtime submodule HEAD/status/last commit/recent reflog
    - superproject submodule status + git status
  - writes artifact to `_bmad_output/evidence/runtime-drift-context-<timestamp>.json`
  - continues existing auto-heal flow after capture

## Validation
- `bash -n ops/repo-health/pilot_step.sh`
- `mise run repo-health:pilot-step` (strict gate clean)

Refs #261
