### PR TITLE
fix(repo-health): ignore runtime drift context artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ htmlcov/
 # BMAD generated evidence artifacts
 _bmad_output/evidence/repo-health-*.json
 _bmad_output/evidence/repo-health-idle-decision-*.json
+_bmad_output/evidence/runtime-drift-context-*.json
 _bmad_output/evidence/closeout/*.json
 _bmad_output/issue-*-execution.md
 agents/hermes/pm/.runtime-scaffold/


### PR DESCRIPTION
## Summary
Fixes a blocker introduced by runtime drift context capture (#263): when drift was detected, the new `runtime-drift-context-*.json` artifact was not ignored, making the worktree dirty before strict gating.

## Change
- `.gitignore`
  - add `_bmad_output/evidence/runtime-drift-context-*.json`

## Why
`repo-health:strict` enforces clean worktree. Unignored forensic artifacts caused strict to fail after a drift-capture cycle even though submodule drift had been healed.

## Validation
- `mise run repo-health:pilot-step`
- strict gate passes clean (`worktree_dirty: false`)

Refs #261
